### PR TITLE
Fix ingressClassName middleware namespacing

### DIFF
--- a/charts/common/templates/classes/_ingress.tpl
+++ b/charts/common/templates/classes/_ingress.tpl
@@ -36,7 +36,7 @@ within the common library.
 
   {{- $mddwrNamespace := "default" }}
   {{- if $values.ingressClassName }}
-  {{- $mddwrNamespace := ( printf "ix-%s" $values.ingressClassName ) }}
+  {{- $mddwrNamespace = ( printf "ix-%s" $values.ingressClassName ) }}
   {{- end }}
 
   {{- $fixedMiddlewares := "" }}


### PR DESCRIPTION
**Description**
When deploying an app with an ingressClassName, the middleware namespace is always `default` instead of using the namespace of the middleware 
⚒️ Fixes  #55 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have tested with a blank chart that changing `:=` to `=` allows the value to be changed away from `"default"`.

**📃 Notes:**
It is not clear to me how I would go about doing an integration test for this fix

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
