### PR TITLE
[Feature] Add common references for theme.park support

### DIFF
--- a/charts/common/templates/classes/_ingress.tpl
+++ b/charts/common/templates/classes/_ingress.tpl
@@ -65,6 +65,18 @@ within the common library.
       {{ $middlewares = ( printf "%s" $fixedMiddlewares ) }}
   {{ end }}
 
+  {{- if .Values.addons.themePark.enabled }}
+    {{/* append the middlewareReference to any additional middleware */}}
+    {{- $middlewareReference := .Values.addons.themePark.middlewareReference -}}
+    {{- if $middlewares }}
+      {{ $middlewares = printf "%s, %s" $middlewares $middlewareReference }}
+    {{- else }}
+      {{ $middlewares = printf "%s" $middlewareReference }}
+    {{- end }}
+    {{/* include theme.park middleware generation */}}
+    {{ ( include "common.classes.themePark" . ) | nindent 0 }}
+  {{- end }}
+
 ---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress

--- a/charts/common/templates/classes/_themePark.tpl
+++ b/charts/common/templates/classes/_themePark.tpl
@@ -1,0 +1,19 @@
+{{- define "common.classes.themePark" -}}
+{{- if .Values.addons.themePark.enabled -}}
+
+{{- $appName := .Chart.Name -}}
+{{- $themeName := .Values.addons.themePark.themeName -}}
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: theme
+spec:
+  plugin:
+    themePark:
+      app: {{ $appName }}
+      theme: {{ $themeName }}
+
+{{- end -}}
+{{- end }}

--- a/charts/common/templates/lib/chart/_values.tpl
+++ b/charts/common/templates/lib/chart/_values.tpl
@@ -280,4 +280,13 @@
   {{- end }}
   {{- end }}
   {{- end }}
+
+  {{/* add reference for theme.park middleware if theme.park addon is enabled */}}
+  {{- if .Values.addons.themePark }}
+    {{- if .Values.addons.themePark.enabled }}
+      {{- $_ := set .Values.addons.themePark "middlewareReference" ( printf "%s-theme@kubernetescrd" .Release.Namespace ) }}
+    {{- end -}}
+  {{- else -}}
+    {{- $_ := dict "enabled" false | set .Values.addons "themePark" -}}
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
This adds support for implementing https://github.com/truecharts/apps/issues/2778.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have created the updates in template files in a fork of `apps` in a few apps templates directory. The template files in the fork work to override the functionality of the `library-charts` and allowed for validating these changes do not impact any functionality before the corresponding `apps` PR is merged.

**📃 Notes:**
I would like to get this merged before the PR to update `apps` so that the overriding templates do not need to be included.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
