### PR TITLE
fix(service): don't set ipFamilyPolicy when svc is ExternalName

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 10.1.4
+version: 10.1.5

--- a/charts/common/templates/class/_service.tpl
+++ b/charts/common/templates/class/_service.tpl
@@ -73,7 +73,7 @@ spec:
   {{- if $values.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ $values.publishNotReadyAddresses }}
   {{- end }}
-  {{- if $values.ipFamilyPolicy }}
+  {{- if (and ($values.ipFamilyPolicy) (ne $svcType "ExternalName")) }}
   ipFamilyPolicy: {{ $values.ipFamilyPolicy }}
   {{- end }}
   {{- with $values.ipFamilies }}

--- a/charts/common/templates/class/_service.tpl
+++ b/charts/common/templates/class/_service.tpl
@@ -76,9 +76,11 @@ spec:
   {{- if (and ($values.ipFamilyPolicy) (ne $svcType "ExternalName")) }}
   ipFamilyPolicy: {{ $values.ipFamilyPolicy }}
   {{- end }}
+  {{ if ne $svcType "ExternalName" }}
   {{- with $values.ipFamilies }}
   ipFamilies:
     {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   ports:
   {{- range $name, $port := $values.ports }}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  https://github.com/truecharts/apps/issues/2935

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
