### PR TITLE
Don't `b64enc` ClickHouse values

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 10.3.0
+version: 10.3.1

--- a/charts/common/templates/lib/dependencies/_clickhouseInjector.tpl
+++ b/charts/common/templates/lib/dependencies/_clickhouseInjector.tpl
@@ -33,14 +33,14 @@ data:
   url:                 {{ $url | b64enc | quote }}
   jdbc:                {{ $jdbc | b64enc | quote }}
 
-{{- $_ := set .Values.clickhouse     "clickhousePassword" ($dbPass | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "plain"              ($host | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "plainhost"          ($host | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "plainport"          ($portHost | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "plainporthost"      ($portHost  | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "ping"               ($ping  | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "complete"           ($url | b64enc | quote) }}
-{{- $_ := set .Values.clickhouse.url "jdbc"               ($jdbc | b64enc | quote) }}
+{{- $_ := set .Values.clickhouse     "clickhousePassword" ($dbPass | quote) }}
+{{- $_ := set .Values.clickhouse.url "plain"              ($host | quote) }}
+{{- $_ := set .Values.clickhouse.url "plainhost"          ($host | quote) }}
+{{- $_ := set .Values.clickhouse.url "plainport"          ($portHost | quote) }}
+{{- $_ := set .Values.clickhouse.url "plainporthost"      ($portHost | quote) }}
+{{- $_ := set .Values.clickhouse.url "ping"               ($ping | quote) }}
+{{- $_ := set .Values.clickhouse.url "complete"           ($url | quote) }}
+{{- $_ := set .Values.clickhouse.url "jdbc"               ($jdbc | quote) }}
 
 {{- end }}
 {{- end -}}

--- a/helper-charts/common-test/tests/persistence/volumeclaimtemplates_test.yaml
+++ b/helper-charts/common-test/tests/persistence/volumeclaimtemplates_test.yaml
@@ -20,7 +20,7 @@ tests:
           path: spec.volumeClaimTemplates[0]
           value:
             metadata:
-              name: storage
+              name: 0
             spec:
               accessModes:
                 - ReadWriteOnce


### PR DESCRIPTION
**Description**

I accidentally applied `b64enc` to `values.yaml` and not only the data of the k8s secret.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have opened a PR on [truecharts/pub](https://github.com/truecharts/pub) adding the app icon.
- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
