### PR TITLE
Re-add vpn additionalVolumeMounts

### DIFF
--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog<br>
 
+<a name="common-10.8.2"></a>
+### [common-10.8.2](https://github.com/truecharts/apps/compare/common-10.8.1...common-10.8.2) (2022-11-07)
+
+#### Feat
+
+* Re-add addon.vpn.additionalVolumeMounts
 
 <a name="common-9.1.14"></a>
 ### [common-9.1.14](https://github.com/truecharts/apps/compare/common-9.1.13...common-9.1.14) (2022-03-26)

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 10.8.1
+version: 10.8.2

--- a/charts/common/templates/addons/vpn/openvpn/_container.tpl
+++ b/charts/common/templates/addons/vpn/openvpn/_container.tpl
@@ -61,6 +61,10 @@ volumeMounts:
   - name: vpnconfig
     mountPath: /vpn/vpn.conf
 {{- end }}
+{{- if .Values.addons.vpn.additionalVolumeMounts }}
+  {{- toYaml .Values.addons.vpn.additionalVolumeMounts | nindent 2 }}
+{{- end }}
+
 {{- with .Values.addons.vpn.livenessProbe }}
 livenessProbe:
   {{- toYaml . | nindent 2 }}

--- a/charts/common/templates/addons/vpn/tailscale/_container.tpl
+++ b/charts/common/templates/addons/vpn/tailscale/_container.tpl
@@ -87,6 +87,9 @@ volumeMounts:
     name: shared
   - mountPath: /var/lib/tailscale
     name: {{ printf "%v-%v" .Release.Name "tailscale" }}
+{{- if .Values.addons.vpn.additionalVolumeMounts }}
+  {{- toYaml .Values.addons.vpn.additionalVolumeMounts | nindent 2 }}
+{{- end }}
 {{- with .Values.addons.vpn.livenessProbe }}
 livenessProbe:
   {{- toYaml . | nindent 2 }}

--- a/charts/common/templates/addons/vpn/wireguard/_container.tpl
+++ b/charts/common/templates/addons/vpn/wireguard/_container.tpl
@@ -59,6 +59,9 @@ volumeMounts:
   - name: vpnconfig
     mountPath: /etc/wireguard/wg0.conf
 {{- end }}
+{{- if .Values.addons.vpn.additionalVolumeMounts }}
+  {{- toYaml .Values.addons.vpn.additionalVolumeMounts | nindent 2 }}
+{{- end }}
 {{- with .Values.addons.vpn.livenessProbe }}
 livenessProbe:
   {{- toYaml . | nindent 2 }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -1065,6 +1065,9 @@ addons:
       # See Kubernetes documentation for options.
       hostPathType: "File"
 
+    # -- Additional volume mounts.
+    additionalVolumeMounts: []
+
   # -- The common library supports adding a code-server add-on to access files. It can be configured under this key.
   # For more info, check out [our docs](http://docs.k8s-at-home.com/our-helm-charts/common-library-add-ons/#code-server)
   # @default -- See values.yaml


### PR DESCRIPTION
**Description**

This PR re-adds the `addons.vpn.additionalVolumeMounts` key so users have the possibility to mount arbitrary Volumes.



**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

I used my branch of the common library chart together with the transmission chart like this:

```
❯ gd
diff --git a/charts/stable/transmission/Chart.yaml b/charts/stable/transmission/Chart.yaml
index 8761dc5b6b..381760b2b4 100644
--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 appVersion: "3.00"
 dependencies:
   - name: common
-    repository: https://library-charts.truecharts.org
-    version: 10.8.1
+    # repository: https://library-charts.truecharts.org
+    repository: "file://../../../../library-charts/charts/common"
+    version: 10.8.2
 deprecated: false
 description: fast, easy, and free BitTorrent client.
 home: https://truecharts.org/docs/charts/stable/transmission

❯ cat test.yml 
addons:
  vpn:
    type: wireguard
    additionalVolumeMounts:
      - mountPath: /foo
        name: foo

❯ helm template -f test.yml . | grep -B5 foo
          volumeMounts:
          - mountPath: /shared
            name: shared
          - mountPath: /etc/wireguard/wg0.conf
            name: vpnconfig
          - mountPath: /foo
            name: foo
```

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

