### PR TITLE
feat(common): allow for rootless db-wait and cve-free autopermissions

### DIFF
--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -96,4 +96,4 @@ jobs:
 
     - name: Run chart-testing (install)
       if: needs.lint.outputs.changed == 'true'
-      run: find ./ -type f -name "*.yaml" -exec sed -i 's/tccr.io/ghcr.io/gI' {} \; && ct install --all --config .github/ct-install.yaml --debug
+      run: ct install --all --config .github/ct-install.yaml --debug

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 11.0.9
+version: 11.1.0

--- a/charts/common/templates/lib/controller/_prepare.tpl
+++ b/charts/common/templates/lib/controller/_prepare.tpl
@@ -57,7 +57,8 @@ before chart installation.
   securityContext:
     runAsUser: 568
     runAsGroup: 568
-    fsGroup: 568
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
   resources:
   {{- with .Values.resources }}
     {{- tpl ( toYaml . ) $ | nindent 4 }}

--- a/charts/common/templates/lib/controller/_prepare.tpl
+++ b/charts/common/templates/lib/controller/_prepare.tpl
@@ -5,16 +5,21 @@ before chart installation.
 {{- define "tc.common.controller.prepare" -}}
 {{- $group := .Values.podSecurityContext.fsGroup -}}
 {{- $hostPathMounts := dict -}}
+{{- $autoperms := false -}}
 {{- range $name, $mount := .Values.persistence -}}
   {{- if and $mount.enabled $mount.setPermissions -}}
     {{- $name = default ( $name| toString ) $mount.name -}}
     {{- $_ := set $hostPathMounts $name $mount -}}
+    {{- $autoperms = true -}}
   {{- end -}}
 {{- end }}
-- name: prepare
+{{- if or .Values.mariadb.enabled .Values.redis.enabled .Values.mongodb.enabled .Values.clickhouse.enabled .Values.solr.enabled .Values.postgresql.enabled .Values.cnpg.enabled }}
+- name: db-wait
   image: {{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}
   securityContext:
-    runAsUser: 0
+    runAsUser: 568
+    runAsGroup: 568
+    fsGroup: 568
   resources:
   {{- with .Values.resources }}
     {{- tpl ( toYaml . ) $ | nindent 4 }}
@@ -187,4 +192,43 @@ before chart installation.
     - name: vpnconfig
       mountPath: /vpn/vpn.conf
     {{- end }}
+{{- end }}
+{{- if or $autoperms ( and ( .Values.addons.vpn.configFile.enabled ) ( ne .Values.addons.vpn.type "disabled" ) ( ne .Values.addons.vpn.type "tailscale" ) ) }}
+- name: db-wait
+  image: {{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}
+  securityContext:
+    runAsUser: 0
+  resources:
+  {{- with .Values.resources }}
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
+  command:
+    - "/bin/sh"
+    - "-c"
+    - |
+      /bin/bash <<'EOF'
+      echo "Automatically correcting permissions..."
+      {{- if and ( .Values.addons.vpn.configFile.enabled ) ( ne .Values.addons.vpn.type "disabled" ) ( ne .Values.addons.vpn.type "tailscale" ) }}
+      echo "Automatically correcting permissions for vpn config file..."
+      /usr/bin/nfs4xdr_winacl -a chown -O 568 -G 568 -c /vpn/vpn.conf -p /vpn/vpn.conf || echo "Failed setting permissions..."
+      {{- end }}
+      {{- range $_, $hpm := $hostPathMounts }}
+      echo "Automatically correcting permissions for {{ $hpm.mountPath }}..."
+      /usr/bin/nfs4xdr_winacl -a chown -G {{ $group }} -r -c {{ tpl $hpm.mountPath $ | squote }} -p {{ tpl $hpm.mountPath $ | squote }} || echo "Failed setting permissions..."
+      {{- end }}
+      EOF
+
+  volumeMounts:
+    {{- range $name, $hpm := $hostPathMounts }}
+    - name: {{ $name }}
+      mountPath: {{ $hpm.mountPath }}
+      {{- if $hpm.subPath }}
+      subPath: {{ $hpm.subPath }}
+      {{- end }}
+    {{- end }}
+    {{- if and ( .Values.addons.vpn.configFile.enabled ) ( ne .Values.addons.vpn.type "disabled" ) ( ne .Values.addons.vpn.type "tailscale" ) }}
+    - name: vpnconfig
+      mountPath: /vpn/vpn.conf
+    {{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/common/templates/lib/controller/_prepare.tpl
+++ b/charts/common/templates/lib/controller/_prepare.tpl
@@ -26,7 +26,7 @@ before chart installation.
     - "/bin/sh"
     - "-c"
     - |
-      /bin/bash <<'EOF'
+      /bin/sh <<'EOF'
       echo "Automatically correcting permissions..."
       {{- if and ( .Values.addons.vpn.configFile.enabled ) ( ne .Values.addons.vpn.type "disabled" ) ( ne .Values.addons.vpn.type "tailscale" ) }}
       echo "Automatically correcting permissions for vpn config file..."

--- a/charts/common/templates/lib/util/_manifest-updater.tpl
+++ b/charts/common/templates/lib/util/_manifest-updater.tpl
@@ -35,6 +35,10 @@ spec:
             - name: temp
               mountPath: /tmp
       restartPolicy: Never
+      {{- with (include "tc.common.controller.volumes" . | trim) }}
+      volumes:
+        {{- nindent 8 . }}
+      {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/common/templates/lib/util/_manifest-updater.tpl
+++ b/charts/common/templates/lib/util/_manifest-updater.tpl
@@ -18,6 +18,11 @@ spec:
       containers:
         - name: {{ $fullName }}-manifests
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
           command:
             - "/bin/sh"
             - "-c"

--- a/charts/common/templates/lib/util/_manifest-updater.tpl
+++ b/charts/common/templates/lib/util/_manifest-updater.tpl
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ $fullName }}-manifests
       containers:
         - name: {{ $fullName }}-manifests
-          image: {{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}
+          image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
           command:
             - "/bin/sh"
             - "-c"

--- a/charts/common/templates/lib/util/_manifest-updater.tpl
+++ b/charts/common/templates/lib/util/_manifest-updater.tpl
@@ -22,7 +22,7 @@ spec:
             - "/bin/sh"
             - "-c"
             - |
-              /bin/bash <<'EOF'
+              /bin/sh <<'EOF'
               echo "installing manifests..."
               kubectl apply --server-side --force-conflicts  -k https://github.com/truecharts/manifests/{{ if .Values.manifests.staging }}staging{{ else }}manifests{{ end }} {{ if .Values.manifests.nonBlocking }} || echo "Manifest application failed..."{{ end }}
               EOF

--- a/charts/common/templates/lib/util/_manifest-updater.tpl
+++ b/charts/common/templates/lib/util/_manifest-updater.tpl
@@ -31,6 +31,9 @@ spec:
               echo "installing manifests..."
               kubectl apply --server-side --force-conflicts  -k https://github.com/truecharts/manifests/{{ if .Values.manifests.staging }}staging{{ else }}manifests{{ end }} {{ if .Values.manifests.nonBlocking }} || echo "Manifest application failed..."{{ end }}
               EOF
+          volumeMounts:
+            - name: temp
+              mountPath: /tmp
       restartPolicy: Never
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -47,6 +47,14 @@ ubuntuImage:
   # -- Specify the redis image pull policy
   pullPolicy: IfNotPresent
 
+alpineImage:
+  # -- Specify the multi-init image
+  repository: tccr.io/truecharts/alpine
+  # -- Specify the redis image tag
+  tag: v3.17.0@sha256:f8607e14a5e456c1b8fe50b7f0c9371b4aae543d23080f5e2fe0bdbb06d2413b
+  # -- Specify the redis image pull policy
+  pullPolicy: IfNotPresent
+
 # -- Used to inject our own operator manifests into SCALE
 manifests:
   enabled: true

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -59,7 +59,7 @@ kubectlImage:
   # -- Specify the multi-init image
   repository: tccr.io/truecharts/kubectl
   # -- Specify the redis image tag
-  tag: v1.26.0@sha256:c860034eb9a01953cf2056b4035fb6da372c8cac5fa5379ace83e9439cf0e92a
+  tag: v1.26.0@sha256:6d6e0e50f28b961ed1c1c6a9c140553238641591fbdc9ac7c1a348636f78c552
   # -- Specify the redis image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -55,6 +55,14 @@ alpineImage:
   # -- Specify the redis image pull policy
   pullPolicy: IfNotPresent
 
+kubectlImage:
+  # -- Specify the multi-init image
+  repository: tccr.io/truecharts/kubectl
+  # -- Specify the redis image tag
+  tag: v1.26.0@sha256:c860034eb9a01953cf2056b4035fb6da372c8cac5fa5379ace83e9439cf0e92a
+  # -- Specify the redis image pull policy
+  pullPolicy: IfNotPresent
+
 # -- Used to inject our own operator manifests into SCALE
 manifests:
   enabled: true

--- a/helper-charts/common-test/tests/pod/initcontainers_test.yaml
+++ b/helper-charts/common-test/tests/pod/initcontainers_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: template-test
 
   - it: with implicit name should pass
@@ -27,7 +27,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: init1
 
   - it: with templated name should pass
@@ -41,5 +41,5 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: RELEASE-NAME-container

--- a/helper-charts/common-test/tests/pod/installcontainers_test.yaml
+++ b/helper-charts/common-test/tests/pod/installcontainers_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: template-test
 
   - it: with implicit name should pass
@@ -31,7 +31,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: install1
 
   - it: with templated name should pass
@@ -47,5 +47,5 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: RELEASE-NAME-container

--- a/helper-charts/common-test/tests/pod/upgradecontainers_test.yaml
+++ b/helper-charts/common-test/tests/pod/upgradecontainers_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: template-test
 
   - it: with implicit name should pass
@@ -31,7 +31,7 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: upgrade1
 
   - it: with templated name should pass
@@ -47,5 +47,5 @@ tests:
           of: Deployment
       - documentIndex: 0
         equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: RELEASE-NAME-container


### PR DESCRIPTION
**Description**
This PR splits the root-requiring and non-root-requiring parts of the default initcontainer.

- The root-requiring part, is now run on a bare-bones alpine image, for added security.
- The database waits, are now running rootless.

In the future more of the initcontainers should be hardened with least-privilage in mine.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
