### PR TITLE
Don't double quote umask value in pod environment variables

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 11.1.2
+version: 11.1.3

--- a/charts/common/helm-values.md
+++ b/charts/common/helm-values.md
@@ -245,7 +245,7 @@ This chart is used by a lot of our Apps to provide sane defaults and logic.
 | resources | object | `{"limits":{"cpu":"4000m","memory":"8Gi"},"requests":{"cpu":"10m","memory":"50Mi"}}` | Set the resource requests / limits for the main container. |
 | schedulerName | string | `nil` | Allows specifying a custom scheduler name |
 | secret | object | `{}` | Use this to populate a secret with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. |
-| security | object | `{"PUID":568,"UMASK":2}` | Set the Process User ID (PUID) env-var seperately |
+| security | object | `{"PUID":568,"UMASK":"002"}` | Set the Process User ID (PUID) env-var seperately |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":[]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Configure the Security Context for the main container |
 | service | object | See below | Configure the services for the chart here. Additional services can be added by adding a dictionary key similar to the 'main' service. |
 | service.main.annotations | object | `{}` | Provide additional annotations which may be required. |

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -52,23 +52,23 @@
   env:
    {{- if and ( not .Values.podSecurityContext.runAsUser) ( .Values.security.PUID ) }}
     - name: PUID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
     - name: USER_ID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
     - name: UID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
    {{- end }}
     - name: UMASK
-      value: {{ tpl ( toYaml .Values.security.UMASK ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.security.UMASK ) $ }}
     - name: UMASK_SET
-      value: {{ tpl ( toYaml .Values.security.UMASK ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.security.UMASK ) $ }}
    {{- if and ( not .Values.podSecurityContext.runAsUser) ( .Values.security.PUID ) }}
     - name: PGID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
     - name: GROUP_ID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
     - name: GID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
    {{- end }}
    {{- if or ( .Values.securityContext.readOnlyRootFilesystem ) ( .Values.securityContext.runAsNonRoot ) }}
     - name: S6_READ_ONLY_ROOT
@@ -82,7 +82,7 @@
       value: "all"
    {{- end }}
     - name: TZ
-      value: {{ tpl ( toYaml .Values.TZ ) $ | quote }}
+      value: {{ tpl ( toYaml .Values.TZ ) $ }}
   {{- with .Values.env }}
     {{- range $k, $v := . }}
       {{- $name := $k }}

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -52,11 +52,11 @@
   env:
    {{- if and ( not .Values.podSecurityContext.runAsUser) ( .Values.security.PUID ) }}
     - name: PUID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
     - name: USER_ID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
     - name: UID
-      value: {{ tpl ( toYaml .Values.security.PUID ) $ }}
+      value: {{ tpl ( toYaml .Values.security.PUID ) $ | quote }}
    {{- end }}
     - name: UMASK
       value: {{ tpl ( toYaml .Values.security.UMASK ) $ }}
@@ -64,11 +64,11 @@
       value: {{ tpl ( toYaml .Values.security.UMASK ) $ }}
    {{- if and ( not .Values.podSecurityContext.runAsUser) ( .Values.security.PUID ) }}
     - name: PGID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
     - name: GROUP_ID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
     - name: GID
-      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ }}
+      value: {{ tpl ( toYaml .Values.podSecurityContext.fsGroup ) $ | quote }}
    {{- end }}
    {{- if or ( .Values.securityContext.readOnlyRootFilesystem ) ( .Values.securityContext.runAsNonRoot ) }}
     - name: S6_READ_ONLY_ROOT
@@ -82,7 +82,7 @@
       value: "all"
    {{- end }}
     - name: TZ
-      value: {{ tpl ( toYaml .Values.TZ ) $ }}
+      value: {{ tpl ( toYaml .Values.TZ ) $ | quote }}
   {{- with .Values.env }}
     {{- range $k, $v := . }}
       {{- $name := $k }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -354,7 +354,7 @@ enableServiceLinks: false
 # -- Set the Process User ID (PUID) env-var seperately
 security:
   PUID: 568
-  UMASK: 002
+  UMASK: "002"
 
 # -- Can be used to set securityContext.capabilities outside of the GUI on TrueNAS SCALE
 customCapabilities:

--- a/helper-charts/common-test/tests/container/env_test.yaml
+++ b/helper-charts/common-test/tests/container/env_test.yaml
@@ -12,9 +12,9 @@ tests:
           path: spec.template.spec.containers[0].env
           value:
             - name: UMASK
-              value: "2"
+              value: "002"
             - name: UMASK_SET
-              value: "2"
+              value: "002"
             - name: S6_READ_ONLY_ROOT
               value: "1"
             - name: NVIDIA_VISIBLE_DEVICES


### PR DESCRIPTION
**Description**

The `UMASK` environment variable is being double quoted in consuming charts. The umask value is particularly tricky because it would be parsed as a valid int and then truncated, e.g. `002` to `2` resulting in an invalid unix umask string to be passed as a commandline argument.

It's being supplied as a string from the TrueNAS form: https://github.com/truecharts/charts/blob/f39157ac79196a33cdd6f5a179170a46c1a2b351/templates/questions/security/security.yaml#L26

It's then being correctly output into values as a yaml string:
```
NAME: makemkv
LAST DEPLOYED: Sun Jan  1 20:29:20 2023
NAMESPACE: ix-makemkv
STATUS: deployed
REVISION: 8
TEST SUITE: None
USER-SUPPLIED VALUES:
TZ: UTC
...
security:
  PUID: 568
  UMASK: "0002"
  editsecurity: true
```

But in the pod's spec it's double quoted because the [toYaml function](https://github.com/helm/helm/blob/eb7150fc61194006c37721a0b92ce82c34909138/pkg/engine/funcs.go#L83) is calling the [yaml.Marshal](https://pkg.go.dev/sigs.k8s.io/yaml#Marshal) function which is correctly quoting it prior to our `toYaml ... | quote` being called.
```
      containers:
        - name: makemkv
          image: tccr.io/truecharts/makemkv:1.22.2@sha256:5f1304e5cf378eea96f5f43ca42d595f6d681fe52661f2ad203e860c2618c049
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: true
            capabilities:
              add: []
              drop: []
            privileged: true
            readOnlyRootFilesystem: false
            runAsNonRoot: false
        
          env:
            - name: PUID
              value: "568"
            - name: USER_ID
              value: "568"
            - name: UID
              value: "568"
            - name: UMASK
              value: "\"0002\""
            - name: UMASK_SET
              value: "\"0002\""
```

Since we need the UID/GID/etc values that are actually passed as integers to be supplied to the pod deployment as strings in env vars, the minimal fix is to remove the `quote` function on just the `umask` value. I think it's redundant in the `TZ` `toYaml` but it's benign otherwise.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - _Technically this change is breaking, as consuming charts could have been set up to expect a doubly-quoted umask_
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

~I have not tested these changes yet. Will the helm CI run test with `"002"` from the [default value](https://github.com/truecharts/charts/blob/f39157ac79196a33cdd6f5a179170a46c1a2b351/templates/questions/security/security.yaml#L27) or is that only evaluated by TrueNAS?~

edit:
It looks like the tests have been testing integer instead of stringy values: https://github.com/truecharts/library-charts/actions/runs/3823134127/jobs/6503985031#step:4:55
They're [updated now](https://github.com/truecharts/library-charts/pull/310/commits/f5f788a6847317ea8d7bd8fd02d07336193d7523) and pass.

**📃 Notes:**
This is my first contribution, it looks like manually bumping the semver version in the Chart.yaml is sufficient here? Then submit a PR to truecharts/charts bumping the common version as well as chart version?

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
