### PR TITLE
feat(common): allow tpl for env expandObjectName, configmap-name and secret-name

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.2.12
+version: 12.2.13

--- a/library/common/templates/lib/container/_env.tpl
+++ b/library/common/templates/lib/container/_env.tpl
@@ -38,8 +38,11 @@ objectData: The object data to be used to render the container.
       key: {{ $obj.key | quote }}
 
           {{- $name = tpl $obj.name $rootCtx -}}
+
           {{- if kindIs "bool" $obj.expandObjectName -}}
             {{- $expandName = $obj.expandObjectName -}}
+          {{- else if eq $obj.expandObjectName "false" -}}
+            {{- $expandName = false -}}
           {{- end -}}
 
           {{- if $expandName -}}

--- a/library/common/templates/lib/container/_envFrom.tpl
+++ b/library/common/templates/lib/container/_envFrom.tpl
@@ -26,6 +26,7 @@ objectData: The object data to be used to render the container.
 
         {{- $objectName := tpl .name $rootCtx -}}
 
+        {{- $expandName := true -}}
           {{- if kindIs "bool" .expandObjectName -}}
             {{- $expandName = .expandObjectName -}}
           {{- else if eq .expandObjectName "false" -}}

--- a/library/common/templates/lib/container/_envFrom.tpl
+++ b/library/common/templates/lib/container/_envFrom.tpl
@@ -26,10 +26,11 @@ objectData: The object data to be used to render the container.
 
         {{- $objectName := tpl .name $rootCtx -}}
 
-        {{- $expandName := true -}}
-        {{- if kindIs "bool" .expandObjectName -}}
-          {{- $expandName = .expandObjectName -}}
-        {{- end -}}
+          {{- if kindIs "bool" .expandObjectName -}}
+            {{- $expandName = .expandObjectName -}}
+          {{- else if eq .expandObjectName "false" -}}
+            {{- $expandName = false -}}
+          {{- end -}}
 
         {{- if $expandName -}}
           {{- $object := dict -}}

--- a/library/common/templates/spawner/_configmap.tpl
+++ b/library/common/templates/spawner/_configmap.tpl
@@ -7,7 +7,15 @@
 
   {{- range $name, $configmap := .Values.configmap -}}
 
-    {{- if $configmap.enabled -}}
+    {{- $enabled := false -}}
+
+    {{- if kindIs "bool" $configmap.enabled -}}
+      {{- $enabled = $configmap.enabled -}}
+    {{- else if eq $configmap.enabled "true" -}}
+      {{- $enabled = true -}}
+    {{- end -}}
+
+    {{- if $enabled -}}
 
       {{/* Create a copy of the configmap */}}
       {{- $objectData := (mustDeepCopy $configmap) -}}

--- a/library/common/templates/spawner/_secret.tpl
+++ b/library/common/templates/spawner/_secret.tpl
@@ -7,7 +7,15 @@
 
   {{- range $name, $secret := .Values.secret -}}
 
-    {{- if $secret.enabled -}}
+    {{- $enabled := false -}}
+
+    {{- if kindIs "bool" $secret.enabled -}}
+      {{- $enabled = $secret.enabled -}}
+    {{- else if eq $secret.enabled "true" -}}
+      {{- $enabled = true -}}
+    {{- end -}}
+
+    {{- if $enabled -}}
 
       {{/* Create a copy of the secret */}}
       {{- $objectData := (mustDeepCopy $secret) -}}


### PR DESCRIPTION
**Description**
This fixes some issues where secrets/configmaps couldn't be dynamicly be disabled or could env references be dynamically switch between expanded and non-expanded object names

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
