### PR TITLE
feat(cnpg): add postgresql section for custom config

### DIFF
--- a/library/common-test/tests/cnpg/custom_conf_test.yaml
+++ b/library/common-test/tests/cnpg/custom_conf_test.yaml
@@ -1,0 +1,29 @@
+suite: cnpg custom conf test
+templates:
+  - common.yaml
+tests:
+  - it: should pass with custom-conf
+    set:
+      cnpg:
+        main:
+          enabled: true
+          primary: true
+          user: app
+          database: app
+          postgresql:
+            key1: value1
+            key2: '{{ printf "test-tpl" }}'
+    asserts:
+      - documentIndex: &clusterDoc 0
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            postgresql:
+              key1: value1
+              key2: test-tpl

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.2.15
+version: 12.2.16

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -66,4 +66,7 @@ spec:
     inProgress: false
     reusePVC: on
 
+  postgresql:
+    {{- tpl ( $values.postgresql | toYaml ) $ | nindent 4 }}
+
 {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -708,6 +708,9 @@ cnpg:
       enablePodMonitor: true
     # -- contains credentials and urls output by generator
     creds: {}
+    # -- contains postgresql settings
+    # ref: https://cloudnative-pg.io/documentation/1.19/postgresql_conf/#the-postgresql-section
+    postgresql: {}
 
 # -- Redis dependency configuration
 # @default -- See below


### PR DESCRIPTION
**Description**
As requested by @stavros-k allow custom postgresql config on a per-chart basis

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
