### PR TITLE
fix(common): prevent random nodePorts being assigned for LoadBalancer

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.2.24
+version: 12.2.25

--- a/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
+++ b/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
@@ -10,6 +10,7 @@ objectData: The service object data
   {{- $objectData := .objectData }}
 
 type: LoadBalancer
+allocateLoadBalancerNodePorts: {{- with $objectData.allocateLoadBalancerNodePorts | default false }}
 publishNotReadyAddresses: {{ include "tc.v1.common.lib.service.publishNotReadyAddresses" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim }}
   {{- with (include "tc.v1.common.lib.service.externalIPs" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim) }}
 externalIPs:

--- a/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
+++ b/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
@@ -10,7 +10,7 @@ objectData: The service object data
   {{- $objectData := .objectData }}
 
 type: LoadBalancer
-allocateLoadBalancerNodePorts: {{- with $objectData.allocateLoadBalancerNodePorts | default false }}
+allocateLoadBalancerNodePorts: {{ $objectData.allocateLoadBalancerNodePorts | default false }}
 publishNotReadyAddresses: {{ include "tc.v1.common.lib.service.publishNotReadyAddresses" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim }}
   {{- with (include "tc.v1.common.lib.service.externalIPs" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim) }}
 externalIPs:


### PR DESCRIPTION
**Description**
The default setting is enabled, which causes SEVERE security concerns, exposing apps on random ports for everyone to exploit.
WTF.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
