### PR TITLE
feat(common): Add Chartcontext for appurl and cidrs

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~12.2.0
+  version: ~12.3.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.2.33
+version: 12.3.0

--- a/library/common/templates/lib/util/_chartcontext.tpl
+++ b/library/common/templates/lib/util/_chartcontext.tpl
@@ -1,0 +1,114 @@
+{{/* Returns the primary Workload object */}}
+{{- define "tc.v1.common.lib.util.chartcontext" -}}
+  {{/* Create defaults */}}
+  {{- $protocol := "https" -}}
+  {{- $host := "$node_ip" -}}
+  {{- $port := "443" -}}
+  {{- $url := "" -}}
+  {{- $podCIDR := "172.16.0.0/16" -}}
+    {{- $svcCIDR := "172.17.0.0/16" -}}
+
+  {{/* set temporary storage for ingress name and port */}}
+  {{- $targetIngress := "" -}}
+  {{- $selectedIngress := "" -}}
+
+
+  {{/* Get service, default to primary */}}
+  {{- $selectedService := fromYaml ( include "tc.v1.common.lib.helpers.getSelectedServiceValues" (dict "rootCtx" $ )) }}
+
+  {{/* read loadbalancer IP's for metallb */}}
+  {{- if eq $selectedService.type "LoadBalancer" -}}
+    {{- with $selectedService.loadBalancerIP -}}
+      {{- $host = toString . -}}
+    {{- end -}}
+
+    {{/* set temporary storage for port name and port */}}
+    {{- $targetPort := "" -}}
+    {{- $selectedPort := "" -}}
+    {{/* Fetch port values */}}
+    {{- $targetPort = include "tc.v1.common.lib.util.service.ports.primary" (dict "svcName" $selectedService.shortName "svcValues" $selectedService ) -}}
+    {{- $selectedPort = get $selectedService.ports $targetPort -}}
+    {{/* store port number */}}
+    {{- $port = $selectedPort.port -}}
+  {{- end -}}
+
+  {{/* Fetch ingress values */}}
+  {{- $targetIngress = ( include "tc.v1.common.lib.util.ingress.primary" $ ) -}}
+  {{- $selectedIngress = get $.Values.ingress $targetIngress -}}
+
+  {{/* store host from ingress number */}}
+  {{- if $selectedIngress -}}
+    {{- if $selectedIngress.enabled -}}
+      {{- with (index $selectedIngress.hosts 0) }}
+         {{- $host = .host -}}
+      {{- end }}
+      {{/* Get the port for the ingress entrypoint */}}
+      {{- $namespace := "tc-system" }}
+      {{- if $selectedIngress.ingressClassName }}
+        {{- $namespace := ( printf "ix-%s" $selectedIngress.ingressClassName ) }}
+      {{- end }}
+      {{- $traefikportalhook := lookup "v1" "ConfigMap" $namespace "portalhook" }}
+      {{- $entrypoint := "websecure" }}
+      {{- if $selectedIngress.entrypoint }}
+        {{- $entrypoint = $selectedIngress.entrypoint }}
+      {{- end }}
+      {{- if $traefikportalhook }}
+        {{- if ( index $traefikportalhook.data $entrypoint ) }}
+          {{- $port = ( index $traefikportalhook.data $entrypoint ) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- $port = ( toString $port ) -}}
+
+  {{/* sanitise */}}
+  {{- if eq $port "443" -}}
+    {{- $protocol = "https" -}}
+  {{- end -}}
+
+  {{- if eq $port "80" -}}
+    {{- $protocol = "http" -}}
+  {{- end -}}
+
+  {{- if or ( and ( eq $protocol "https" )  ( eq $port "443" ) ) ( and ( eq $protocol "http" )  ( eq $port "80" ) ) -}}
+    {{- $port = "" -}}
+  {{- end -}}
+
+  {{- $port = toString $port -}}
+
+  {{/* Construct URL*/}}
+  {{- if $port -}}
+  {{- $url = printf "%s://%s:%s%s" $protocol $host $port -}}
+  {{- else -}}
+  {{- $url = printf "%s://%s%s" $protocol $host -}}
+  {{- end -}}
+
+  {{/* TrueNAS SCALE specific code */}}
+  {{- if $.Values.ixChartContext -}}
+      {{- if $.Values.ixChartContext.kubernetes_config -}}
+          {{- $podCIDR = $.Values.ixChartContext.kubernetes_config.cluster_cidr -}}
+        {{- $svcCIDR = $.Values.ixChartContext.kubernetes_config.service_cidr -}}
+        {{- end -}}
+    {{- else -}}
+      {{/* TODO: Find ways to implement CIDR detection */}}
+      {{- end -}}
+
+    {{- if $.Values.chartContext -}}
+      {{- if $.Values.chartContext.APPURL -}}
+        {{- $url = $.Values.chartContext.APPURL -}}
+      {{- end -}}
+
+      {{- if $.Values.chartContext.podCIDR -}}
+        {{- $podCIDR = $.Values.chartContext.podCIDR -}}
+      {{- end -}}
+
+      {{- if $.Values.chartContext.svcCIDR -}}
+        {{- $svcCIDR = $.Values.chartContext.svcCIDR -}}
+      {{- end -}}
+    {{- end -}}
+
+      {{- $_ := set $.Values.chartContext "APPURL" $url -}}
+      {{- $_ := set $.Values.chartContext "podCIDR" $podCIDR -}}
+    {{- $_ := set $.Values.chartContext "svcCIDR" $svcCIDR -}}
+{{- end -}}

--- a/library/common/templates/loader/_init.tpl
+++ b/library/common/templates/loader/_init.tpl
@@ -1,10 +1,13 @@
 {{/* Initialiaze values of the chart */}}
-
 {{- define "tc.v1.common.loader.init" -}}
 
   {{/* Merge chart values and the common chart defaults */}}
   {{- include "tc.v1.common.values.init" . -}}
 
+  {{/* Ensure TrueCharts chart context information is available */}}
+  {{- include "tc.v1.common.lib.util.chartcontext" . -}}
+
+  {{/* Add manifest manager pre-install and pre-update job */}}
   {{- include "tc.v1.common.lib.util.manifest.manage" . | nindent 0 -}}
 
   {{/* Autogenerate postgresql passwords if needed */}}

--- a/library/common/templates/spawner/_portal.tpl
+++ b/library/common/templates/spawner/_portal.tpl
@@ -143,10 +143,6 @@
         {{- include "tc.v1.common.lib.configmap.validation" (dict "objectData" $configMap) -}}
         {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $configMap "caller" "ConfigMap") -}}
 
-        {{- if eq $name "open" -}}
-        {{- $_ := set $.Values "APPURL" $url -}}
-        {{- end -}}
-
         {{- if $.Values.ixChartContext -}}
         {{/* Call class to create the object */}}
         {{- include "tc.v1.common.class.configmap" (dict "rootCtx" $ "objectData" $configMap) -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -63,6 +63,11 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
+chartContext:
+  APPURL: ""
+  podCIDR: ""
+  svcCIDR: ""
+
 # -- Security Context
 securityContext:
   # -- Container security context for all containers


### PR DESCRIPTION
**Description**
We need our own chartContext available with things like an application url (taking LB and ingress into account) and potential place to save CIDR info in a platform agnostic way

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
