### PR TITLE
fix(common): allow for more caps when running as root and bundle the disable

### DIFF
--- a/library/common-test/tests/container/securityContext_test.yaml
+++ b/library/common-test/tests/container/securityContext_test.yaml
@@ -952,57 +952,7 @@ tests:
                   runAsGroup: 0
                   runAsNonRoot: false
                   capabilities:
-                    disableAutoCapCHOWN: not-bool
+                    disableS6Caps: not-bool
     asserts:
       - failedTemplate:
           errorMessage: Container - Expected <securityContext.capabilities.disableAutoCapCHOWN> to be [bool], but got [not-bool] of type [string]
-
-  - it: should fail capabilities.disableAutoCapSETUID not a bool
-    set:
-      image: *image
-      workload:
-        workload-name1:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              container-name1:
-                enabled: true
-                primary: true
-                imageSelector: image
-                probes: *probes
-                securityContext:
-                  runAsUser: 0
-                  runAsGroup: 0
-                  runAsNonRoot: false
-                  capabilities:
-                    disableAutoCapSETUID: not-bool
-    asserts:
-      - failedTemplate:
-          errorMessage: Container - Expected <securityContext.capabilities.disableAutoCapSETUID> to be [bool], but got [not-bool] of type [string]
-
-  - it: should fail capabilities.disableAutoCapSETGID not a bool
-    set:
-      image: *image
-      workload:
-        workload-name1:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              container-name1:
-                enabled: true
-                primary: true
-                imageSelector: image
-                probes: *probes
-                securityContext:
-                  runAsUser: 0
-                  runAsGroup: 0
-                  runAsNonRoot: false
-                  capabilities:
-                    disableAutoCapSETGID: not-bool
-    asserts:
-      - failedTemplate:
-          errorMessage: Container - Expected <securityContext.capabilities.disableAutoCapSETGID> to be [bool], but got [not-bool] of type [string]

--- a/library/common-test/tests/container/securityContext_test.yaml
+++ b/library/common-test/tests/container/securityContext_test.yaml
@@ -94,6 +94,8 @@ tests:
                   - CHOWN
                   - SETUID
                   - SETGID
+                  - FOWNER
+                  - DAC_OVERRIDE
                 drop:
                   - ALL
 
@@ -669,6 +671,8 @@ tests:
                   - CHOWN
                   - SETUID
                   - SETGID
+                  - FOWNER
+                  - DAC_OVERRIDE
                 drop:
                   - ALL
 
@@ -932,7 +936,7 @@ tests:
       - failedTemplate:
           errorMessage: Container - Expected <securityContext.capabilities.drop> to be [list], but got [string]
 
-  - it: should fail capabilities.disableAutoCapCHOWN not a bool
+  - it: should fail capabilities.disableS6Caps not a bool
     set:
       image: *image
       workload:
@@ -955,4 +959,4 @@ tests:
                     disableS6Caps: not-bool
     asserts:
       - failedTemplate:
-          errorMessage: Container - Expected <securityContext.capabilities.disableAutoCapCHOWN> to be [bool], but got [not-bool] of type [string]
+          errorMessage: Container - Expected <securityContext.capabilities.disableS6Caps> to be [bool], but got [not-bool] of type [string]

--- a/library/common-test/tests/container/securityContext_test.yaml
+++ b/library/common-test/tests/container/securityContext_test.yaml
@@ -500,10 +500,12 @@ tests:
                   - CHOWN
                   - SETUID
                   - SETGID
+                  - FOWNER
+                  - DAC_OVERRIDE
                 drop:
                   - ALL
 
-  - it: should not include SETUID/SETGID when disabled from global
+  - it: should not include extra caps when disabled from global
     set:
       image: *image
       securityContext:
@@ -512,8 +514,7 @@ tests:
           runAsUser: 0
           runAsGroup: 0
           capabilities:
-            disableAutoCapSETUID: true
-            disableAutoCapSETGID: true
+            disableS6Caps: true
       workload:
         workload-name1:
           enabled: true
@@ -547,61 +548,11 @@ tests:
               seccompProfile:
                 type: RuntimeDefault
               capabilities:
-                add:
-                  - CHOWN
+                add: []
                 drop:
                   - ALL
 
-  - it: should not include CHOWN when disabled from global
-    set:
-      image: *image
-      securityContext:
-        container:
-          runAsNonRoot: false
-          runAsUser: 0
-          runAsGroup: 0
-          capabilities:
-            disableAutoCapCHOWN: true
-      workload:
-        workload-name1:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              container-name1:
-                enabled: true
-                primary: true
-                imageSelector: image
-                probes: *probes
-    asserts:
-      - documentIndex: &deploymentDoc 0
-        isKind:
-          of: Deployment
-      - documentIndex: *deploymentDoc
-        isAPIVersion:
-          of: apps/v1
-      - documentIndex: *deploymentDoc
-        isSubset:
-          path: spec.template.spec.containers[0]
-          content:
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              readOnlyRootFilesystem: true
-              allowPrivilegeEscalation: false
-              privileged: false
-              runAsNonRoot: false
-              seccompProfile:
-                type: RuntimeDefault
-              capabilities:
-                add:
-                  - SETUID
-                  - SETGID
-                drop:
-                  - ALL
-
-  - it: should not include SETUID/SETGID when disabled from container level
+  - it: should not include extra caps when disabled from container level
     set:
       image: *image
       workload:
@@ -621,8 +572,7 @@ tests:
                   runAsUser: 0
                   runAsGroup: 0
                   capabilities:
-                    disableAutoCapSETUID: true
-                    disableAutoCapSETGID: true
+                    disableS6Caps: true
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -644,56 +594,7 @@ tests:
               seccompProfile:
                 type: RuntimeDefault
               capabilities:
-                add:
-                  - CHOWN
-                drop:
-                  - ALL
-
-  - it: should not include CHOWN when disabled from container level
-    set:
-      image: *image
-      workload:
-        workload-name1:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              container-name1:
-                enabled: true
-                primary: true
-                imageSelector: image
-                probes: *probes
-                securityContext:
-                  runAsNonRoot: false
-                  runAsUser: 0
-                  runAsGroup: 0
-                  capabilities:
-                    disableAutoCapCHOWN: true
-    asserts:
-      - documentIndex: &deploymentDoc 0
-        isKind:
-          of: Deployment
-      - documentIndex: *deploymentDoc
-        isAPIVersion:
-          of: apps/v1
-      - documentIndex: *deploymentDoc
-        isSubset:
-          path: spec.template.spec.containers[0]
-          content:
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
-              readOnlyRootFilesystem: true
-              allowPrivilegeEscalation: false
-              privileged: false
-              runAsNonRoot: false
-              seccompProfile:
-                type: RuntimeDefault
-              capabilities:
-                add:
-                  - SETUID
-                  - SETGID
+                add: []
                 drop:
                   - ALL
 

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.4.4
+version: 12.4.5

--- a/library/common/templates/lib/container/_securityContext.tpl
+++ b/library/common/templates/lib/container/_securityContext.tpl
@@ -140,7 +140,7 @@ objectData: The object data to be used to render the container.
   {{- if eq (int $secContext.runAsUser) 0 -}}
 
     {{- if not (kindIs "bool" $secContext.capabilitiesdisableS6Caps) -}}
-      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $value (kindOf $value)) -}}
+      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $secContext.capabilitiesdisableS6Caps (kindOf $secContext.capabilitiesdisableS6Caps)) -}}
     {{- end -}}
 
     {{- $addCap := $secContext.capabilities.add -}}

--- a/library/common/templates/lib/container/_securityContext.tpl
+++ b/library/common/templates/lib/container/_securityContext.tpl
@@ -139,11 +139,8 @@ objectData: The object data to be used to render the container.
   */}}
   {{- if eq (int $secContext.runAsUser) 0 -}}
 
-    {{- range $key := (list "CHOWN" "SETUID" "SETGID") -}}
-      {{- $value := (get $secContext.capabilities (printf "disableAutoCap%s" $key)) -}}
-      {{- if not (kindIs "bool" $value) -}}
-        {{- fail (printf "Container - Expected <securityContext.capabilities.disableAutoCap%s> to be [bool], but got [%s] of type [%s]" $key $value (kindOf $value)) -}}
-      {{- end -}}
+    {{- if not (kindIs "bool" $secContext.capabilitiesdisableS6Caps) -}}
+      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $value (kindOf $value)) -}}
     {{- end -}}
 
     {{- $addCap := $secContext.capabilities.add -}}

--- a/library/common/templates/lib/container/_securityContext.tpl
+++ b/library/common/templates/lib/container/_securityContext.tpl
@@ -148,14 +148,12 @@ objectData: The object data to be used to render the container.
 
     {{- $addCap := $secContext.capabilities.add -}}
 
-    {{- if not $secContext.capabilities.disableAutoCapCHOWN -}}
+    {{- if not $secContext.capabilities.disableS6Caps -}}
       {{- $addCap = mustAppend $addCap "CHOWN" -}}
-    {{- end -}}
-    {{- if not $secContext.capabilities.disableAutoCapSETUID }}
       {{- $addCap = mustAppend $addCap "SETUID" -}}
-    {{- end -}}
-    {{- if not $secContext.capabilities.disableAutoCapSETGID }}
       {{- $addCap = mustAppend $addCap "SETGID" -}}
+      {{- $addCap = mustAppend $addCap "FOWNER" -}}
+      {{- $addCap = mustAppend $addCap "DAC_OVERRIDE" -}}
     {{- end -}}
 
     {{- $_ := set $secContext.capabilities "add" $addCap -}}

--- a/library/common/templates/lib/container/_securityContext.tpl
+++ b/library/common/templates/lib/container/_securityContext.tpl
@@ -140,7 +140,7 @@ objectData: The object data to be used to render the container.
   {{- if eq (int $secContext.runAsUser) 0 -}}
 
     {{- if not (kindIs "bool" $secContext.capabilities.disableS6Caps) -}}
-      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $secContext.capabilities.disableS6Caps (kindOf $secContext.capabilities.disableS6Caps)) -}}
+      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps> to be [bool], but got [%s] of type [%s]" $secContext.capabilities.disableS6Caps (kindOf $secContext.capabilities.disableS6Caps)) -}}
     {{- end -}}
 
     {{- $addCap := $secContext.capabilities.add -}}

--- a/library/common/templates/lib/container/_securityContext.tpl
+++ b/library/common/templates/lib/container/_securityContext.tpl
@@ -139,8 +139,8 @@ objectData: The object data to be used to render the container.
   */}}
   {{- if eq (int $secContext.runAsUser) 0 -}}
 
-    {{- if not (kindIs "bool" $secContext.capabilitiesdisableS6Caps) -}}
-      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $secContext.capabilitiesdisableS6Caps (kindOf $secContext.capabilitiesdisableS6Caps)) -}}
+    {{- if not (kindIs "bool" $secContext.capabilities.disableS6Caps) -}}
+      {{- fail (printf "Container - Expected <securityContext.capabilities.disableS6Caps%s> to be [bool], but got [%s] of type [%s]" $secContext.capabilities.disableS6Caps (kindOf $secContext.capabilities.disableS6Caps)) -}}
     {{- end -}}
 
     {{- $addCap := $secContext.capabilities.add -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -85,10 +85,9 @@ securityContext:
       drop:
         - ALL
       # When set to false, it will automatically
-      # add the capability when container runs as ROOT
-      disableAutoCapCHOWN: false
-      disableAutoCapSETUID: false
-      disableAutoCapSETGID: false
+      # add CHOWN, SETUID, SETGID, FOWNER, DAC_OVERRIDE
+      # capabilities ONLY when container runs as ROOT
+      disableS6Caps: false
     # -- PUID for all containers
     # Can be overruled per container
     PUID: 568


### PR DESCRIPTION
**Description**
S6 overlay needs some more caps it looks like.
And with the growth of caps we should also bundle them in one disable toggle.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
