### PR TITLE
fix(gluetun):  gluetun killswitch,disable GlueTun DNS and dynamic gluetun/wireguard cidr whitelist

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.4.16
+version: 12.4.17

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -31,16 +31,16 @@ securityContext:
 env:
   DNS_KEEP_NAMESERVER: on
   DOT: off
-{{- if .Values.addons.vpn.killSwitch }}
+{{- if $.Values.addons.vpn.killSwitch }}
   FIREWALL: "on"
   {{- $excludednetworksv4 := "172.16.0.0/12" -}}
-  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv4 = ( printf "%v,%v" $excludednetworksv4 . ) -}}
   {{- end }}
 
-{{- if .Values.addons.vpn.excludedNetworks_IPv6 -}}
+{{- if $.Values.addons.vpn.excludedNetworks_IPv6 -}}
   {{- $excludednetworksv6 := "" -}}
-  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv6 = ( printf "%v,%v" $excludednetworksv6 . ) -}}
   {{- end }}
   FIREWALL_OUTBOUND_SUBNETS: {{ ( printf "%v,%v" $excludednetworksv4 $excludednetworksv6 ) | quote }}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -30,6 +30,7 @@ securityContext:
 
 env:
   DNS_KEEP_NAMESERVER: on
+  DOT: off
 {{- with $.Values.addons.vpn.env }}
   {{- . | toYaml | nindent 2 }}
 {{- end -}}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -31,28 +31,28 @@ securityContext:
 env:
   DNS_KEEP_NAMESERVER: on
   DOT: off
-{{- with $.Values.addons.vpn.env }}
-  {{- . | toYaml | nindent 2 }}
-{{- end -}}
-
 {{- if .Values.addons.vpn.killSwitch }}
   FIREWALL: "on"
   {{- $excludednetworksv4 := "172.16.0.0/12" -}}
   {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
-    {{- $excludednetworksv4 = ( printf "%v;%v" $excludednetworksv4 . ) -}}
+    {{- $excludednetworksv4 = ( printf "%v,%v" $excludednetworksv4 . ) -}}
   {{- end }}
 
 {{- if .Values.addons.vpn.excludedNetworks_IPv6 -}}
   {{- $excludednetworksv6 := "" -}}
   {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
-    {{- $excludednetworksv6 = ( printf "%v;%v" $excludednetworksv6 . ) -}}
+    {{- $excludednetworksv6 = ( printf "%v,%v" $excludednetworksv6 . ) -}}
   {{- end }}
-  FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworksv4 }},{{ $excludednetworksv6 }}
+  FIREWALL_OUTBOUND_SUBNETS: {{ ( printf "%v,%v" $excludednetworksv4 $excludednetworksv6 ) | quote }}
 {{- else -}}
   FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworksv4 | quote }}
 {{- end -}}
 {{- else -}}
   FIREWALL: "off"
+{{- end -}}
+
+{{- with $.Values.addons.vpn.env }}
+  {{- . | toYaml | nindent 2 }}
 {{- end -}}
 
 {{- range $envList := $.Values.addons.vpn.envList -}}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -29,8 +29,29 @@ securityContext:
       - SYS_MODULE
 
 env:
+  DNS_KEEP_NAMESERVER: on
 {{- with $.Values.addons.vpn.env }}
   {{- . | toYaml | nindent 2 }}
+{{- end -}}
+
+{{- if .Values.addons.vpn.killSwitch }}
+  FIREWALL: "on"
+  {{- $excludednetworksv4 := "172.16.0.0/12" -}}
+  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+    {{- $excludednetworksv4 = ( printf "%v;%v" $excludednetworksv4 . ) -}}
+  {{- end }}
+  
+{{- if .Values.addons.vpn.excludedNetworks_IPv6 -}}
+  {{- $excludednetworksv6 := "" -}}
+  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+    {{- $excludednetworksv6 = ( printf "%v;%v" $excludednetworksv6 . ) -}}
+  {{- end }}
+  FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworksv4 }},{{ $excludednetworksv6 }}
+{{- else -}}
+  FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworksv4 | quote }}
+{{- end -}}
+{{- else -}}
+  FIREWALL: "off"
 {{- end -}}
 
 {{- range $envList := $.Values.addons.vpn.envList -}}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -41,7 +41,7 @@ env:
   {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv4 = ( printf "%v;%v" $excludednetworksv4 . ) -}}
   {{- end }}
-  
+
 {{- if .Values.addons.vpn.excludedNetworks_IPv6 -}}
   {{- $excludednetworksv6 := "" -}}
   {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -32,24 +32,18 @@ env:
   DNS_KEEP_NAMESERVER: on
   DOT: off
 {{- if $.Values.addons.vpn.killSwitch }}
+{{- $excludednetworks := ( printf "%v,%v" $.Values.chartContext.podCIDR $.Values.chartContext.svcCIDR ) -}}
+{{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- $excludednetworks = ( printf "%v,%v" $excludednetworks . ) -}}
+{{- end }}
+{{- range $.Values.addons.vpn.excludedNetworks_IPv6 -}}
+  {{- $excludednetworksv6 = ( printf "%v,%v" $excludednetworks . ) -}}
+{{- end }}
   FIREWALL: "on"
-  {{- $excludednetworksv4 := "172.16.0.0/12" -}}
-  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
-    {{- $excludednetworksv4 = ( printf "%v,%v" $excludednetworksv4 . ) -}}
-  {{- end }}
-
-{{- if $.Values.addons.vpn.excludedNetworks_IPv6 -}}
-  {{- $excludednetworksv6 := "" -}}
-  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
-    {{- $excludednetworksv6 = ( printf "%v,%v" $excludednetworksv6 . ) -}}
-  {{- end }}
-  FIREWALL_OUTBOUND_SUBNETS: {{ ( printf "%v,%v" $excludednetworksv4 $excludednetworksv6 ) | quote }}
-{{- else -}}
-  FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworksv4 | quote }}
-{{- end -}}
-{{- else -}}
+  FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworks | quote }}
+{{- else }}
   FIREWALL: "off"
-{{- end -}}
+{{- end }}
 
 {{- with $.Values.addons.vpn.env }}
   {{- . | toYaml | nindent 2 }}

--- a/library/common/templates/addons/vpn/_openvpnContainer.tpl
+++ b/library/common/templates/addons/vpn/_openvpnContainer.tpl
@@ -30,21 +30,21 @@ env:
 {{- with $.Values.addons.vpn.env }}
   {{- . | toYaml | nindent 2 }}
 {{- end }}
-  {{- if and .Values.addons.vpn.openvpn.username .Values.addons.vpn.openvpn.password }}
-  VPN_AUTH: {{ (printf "%v;%v" .Values.addons.vpn.openvpn.username .Values.addons.vpn.openvpn.password) }}
+  {{- if and $.Values.addons.vpn.openvpn.username $.Values.addons.vpn.openvpn.password }}
+  VPN_AUTH: {{ (printf "%v;%v" $.Values.addons.vpn.openvpn.username $.Values.addons.vpn.openvpn.password) }}
   {{- end -}}
-{{- if .Values.addons.vpn.killSwitch }}
+{{- if $.Values.addons.vpn.killSwitch }}
   FIREWALL: "ON"
   ROUTE_1: "172.16.0.0/12"
-  {{- range $index, $value := .Values.addons.vpn.excludedNetworks_IPv4 }}
+  {{- range $index, $value := $.Values.addons.vpn.excludedNetworks_IPv4 }}
   ROUTE_{{ add $index 2 }}: {{ $value | quote }}
   {{- end -}}
-{{- if .Values.addons.vpn.excludedNetworks_IPv6 }}
+{{- if $.Values.addons.vpn.excludedNetworks_IPv6 }}
   {{- $excludednetworksv6 := "" -}}
-  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv6 = ( printf "%v;%v" $excludednetworksv6 . ) -}}
   {{- end -}}
-  {{- range $index, $value := .Values.addons.vpn.excludedNetworks_IPv6 }}
+  {{- range $index, $value := $.Values.addons.vpn.excludedNetworks_IPv6 }}
   ROUTE6_{{ add $index 1 }}: {{ $value | quote }}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/addons/vpn/_openvpnContainer.tpl
+++ b/library/common/templates/addons/vpn/_openvpnContainer.tpl
@@ -34,20 +34,28 @@ env:
   VPN_AUTH: {{ (printf "%v;%v" $.Values.addons.vpn.openvpn.username $.Values.addons.vpn.openvpn.password) }}
   {{- end -}}
 {{- if $.Values.addons.vpn.killSwitch }}
+{{- $ipv4list := $.Values.addons.vpn.excludedNetworks_IPv4 }}
+
+{{- if $.Values.chartContext.podCIDR }}
+{{- $ipv4list = append $ipv4list $.Values.chartContext.podCIDR }}
+{{- end }}
+{{- if $.Values.chartContext.svcCIDR }}
+{{- $ipv4list = append $ipv4list $.Values.chartContext.svcCIDR }}
+{{- end }}
+
   FIREWALL: "ON"
-  ROUTE_1: "172.16.0.0/12"
-  {{- range $index, $value := $.Values.addons.vpn.excludedNetworks_IPv4 }}
-  ROUTE_{{ add $index 2 }}: {{ $value | quote }}
-  {{- end -}}
+  {{- range $index, $value := $ipv4list }}
+  ROUTE_{{ add $index 1 }}: {{ $value | quote }}
+  {{- end }}
 {{- if $.Values.addons.vpn.excludedNetworks_IPv6 }}
   {{- $excludednetworksv6 := "" -}}
   {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv6 = ( printf "%v;%v" $excludednetworksv6 . ) -}}
-  {{- end -}}
+  {{- end }}
   {{- range $index, $value := $.Values.addons.vpn.excludedNetworks_IPv6 }}
   ROUTE6_{{ add $index 1 }}: {{ $value | quote }}
-  {{- end -}}
-{{- end -}}
+  {{- end }}
+{{- end }}
 {{- end -}}
 
 {{- range $envList := $.Values.addons.vpn.envList -}}

--- a/library/common/templates/addons/vpn/_wireguardContainer.tpl
+++ b/library/common/templates/addons/vpn/_wireguardContainer.tpl
@@ -35,19 +35,19 @@ env:
 {{- end }}
   SEPARATOR: ";"
   IPTABLES_BACKEND: "nft"
-{{- if .Values.addons.vpn.killSwitch }}
+{{- if $.Values.addons.vpn.killSwitch }}
   KILLSWITCH: "true"
   {{- $excludednetworksv4 := "172.16.0.0/12" -}}
-  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv4 = ( printf "%v;%v" $excludednetworksv4 . ) -}}
   {{- end }}
   KILLSWITCH_EXCLUDEDNETWORKS_IPV4: {{ $excludednetworksv4 | quote }}
-{{- if .Values.addons.vpn.excludedNetworks_IPv6 -}}
+{{- if $.Values.addons.vpn.excludedNetworks_IPv6 -}}
   {{- $excludednetworksv6 := "" -}}
-  {{- range .Values.addons.vpn.excludedNetworks_IPv4 -}}
+  {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv6 = ( printf "%v;%v" $excludednetworksv6 . ) -}}
   {{- end }}
-  KILLSWITCH_EXCLUDEDNETWORKS_IPV6: {{ .Values.addons.vpn.excludedNetworks_IPv6 | quote }}
+  KILLSWITCH_EXCLUDEDNETWORKS_IPV6: {{ $.Values.addons.vpn.excludedNetworks_IPv6 | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/library/common/templates/addons/vpn/_wireguardContainer.tpl
+++ b/library/common/templates/addons/vpn/_wireguardContainer.tpl
@@ -37,7 +37,7 @@ env:
   IPTABLES_BACKEND: "nft"
 {{- if $.Values.addons.vpn.killSwitch }}
   KILLSWITCH: "true"
-  {{- $excludednetworksv4 := "172.16.0.0/12" -}}
+  {{- $excludednetworksv4 := ( printf "%v;%v" $.Values.chartContext.podCIDR $.Values.chartContext.svcCIDR ) -}}
   {{- range $.Values.addons.vpn.excludedNetworks_IPv4 -}}
     {{- $excludednetworksv4 = ( printf "%v;%v" $excludednetworksv4 . ) -}}
   {{- end }}


### PR DESCRIPTION
**Description**
- Allows the killswitch to be used on Gluetun
- Disable most of the GlueTun DNS settings
- Adds dynamic auto-whitelisted CIDR's (cluster CIDR's) based on chartContext for GlueTun and Wireguard
- Cleans up some of the VPN provider code

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
