### PR TITLE
Revert a fix for endpointslice

### DIFF
--- a/library/common-test/tests/service/external_ip_test.yaml
+++ b/library/common-test/tests/service/external_ip_test.yaml
@@ -96,7 +96,6 @@ tests:
             - name: port-name
               port: 12345
               protocol: TCP
-              targetPort: 12345
             - name: port-name2
               port: 12344
               protocol: TCP
@@ -134,7 +133,7 @@ tests:
               port: 12345
               protocol: TCP
             - name: port-name2
-              port: 12344
+              port: 12346
               protocol: TCP
               appProtocol: http
       - documentIndex: *endpointSliceDoc

--- a/library/common-test/tests/service/external_ip_test.yaml
+++ b/library/common-test/tests/service/external_ip_test.yaml
@@ -96,6 +96,7 @@ tests:
             - name: port-name
               port: 12345
               protocol: TCP
+              targetPort: 12345
             - name: port-name2
               port: 12344
               protocol: TCP

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.4.23
+version: 12.4.24

--- a/library/common/templates/lib/endpointSlice/_ports.tpl
+++ b/library/common/templates/lib/endpointSlice/_ports.tpl
@@ -13,7 +13,7 @@ objectData: The object data of the service
   {{- range $name, $portValues := $objectData.ports -}}
     {{- if $portValues.enabled -}}
       {{- $protocol := $rootCtx.Values.fallbackDefaults.serviceProtocol -}} {{/* Default to fallback protocol, if no protocol is defined */}}
-      {{- $port := $portValues.port -}}
+      {{- $port := $portValues.targetPort | default $portValues.port -}}
 
       {{/* Expand targetPort */}}
       {{- if (kindIs "string" $port) -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

EndpointSlice's `port` must point to the port the server is listenting (the same port Service's targetPort is pointing)
TL;DR Service's `targetPort` + EndpointSlice's `port` must match
https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
