### PR TITLE
fix(manifestManager): Handle failed/completed pods before waiting for the Ready pods + increase deafult pvc size

### DIFF
--- a/library/common-test/tests/persistence/pvc_data_test.yaml
+++ b/library/common-test/tests/persistence/pvc_data_test.yaml
@@ -8,6 +8,7 @@ tests:
         my-volume1:
           enabled: true
           type: pvc
+          size: 1Gi
     asserts:
       - documentIndex: &pvcDoc 0
         isKind:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.6.1
+version: 12.6.2

--- a/library/common/templates/lib/util/_manifest_manager.tpl
+++ b/library/common/templates/lib/util/_manifest_manager.tpl
@@ -75,13 +75,28 @@ spec:
             - |
               /bin/sh <<'EOF'
               touch /tmp/healthy
-              echo "installing manifests..."
-              kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ if .Values.manifestManager.staging }}staging{{ else }}manifests{{ end }} || kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ if .Values.manifestManager.staging }}staging{{ else }}manifests || echo "job failed..."{{ end }}
+              echo "Installing manifests..."
+              {{ $branch := ternary "staging" "manifests" .Values.manifestManager.staging }}
+
+              kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ $branch }} || \
+              kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ $branch }} \
+              {{ ternary "|| echo 'Job failed...'" "" .Values.manifestManager.staging }}
+
               echo "Install finished..."
+
               echo "Starting waits and checks..."
+              kubectl delete pod --field-selector=status.phase==Succeeded -n cnpg-system || echo "Delete of Completed Pods failed..."
+              kubectl delete pod --field-selector=status.phase==Failed -n cnpg-system || echo "Delete of Failed Pods failed..."
               kubectl wait --namespace cnpg-system --for=condition=ready pod --selector=app.kubernetes.io/name=cloudnative-pg --timeout=60s || echo "metallb-system wait failed..."
+
+              kubectl delete pod --field-selector=status.phase==Succeeded -n metallb-system || echo "Delete of Completed Pods failed..."
+              kubectl delete pod --field-selector=status.phase==Failed -n metallb-system || echo "Delete of Failed Pods failed..."
               kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=60s || echo "metallb-system wait failed..."
+
+              kubectl delete pod --field-selector=status.phase==Succeeded -n cert-manager || echo "Delete of Completed Pods failed..."
+              kubectl delete pod --field-selector=status.phase==Failed -n cert-manager || echo "Delete of Failed Pods failed..."
               kubectl wait --namespace cert-manager --for=condition=ready pod --selector=app.kubernetes.io/instance=cert-manager --timeout=60s || echo "cert-manager wait failed..."
+
               cmctl check api --wait=1m || echo "cmctl wait failed..."
               EOF
           volumeMounts:

--- a/library/common/templates/lib/util/_manifest_manager.tpl
+++ b/library/common/templates/lib/util/_manifest_manager.tpl
@@ -80,7 +80,7 @@ spec:
 
               kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ $branch }} || \
               kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ $branch }} \
-              {{ ternary "|| echo 'Job failed...'" "" .Values.manifestManager.staging }}
+              {{ ternary "|| echo 'Job failed...'" "&& echo 'Job succeeded...'" .Values.manifestManager.staging }}
 
               echo "Install finished..."
 

--- a/library/common/templates/lib/util/_manifest_manager.tpl
+++ b/library/common/templates/lib/util/_manifest_manager.tpl
@@ -80,7 +80,7 @@ spec:
 
               kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ $branch }} || \
               kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ $branch }} \
-              {{ ternary "|| echo 'Job failed...'" "&& echo 'Job succeeded...'" .Values.manifestManager.staging }}
+              {{ ternary "&& echo 'Job succeeded...'" "|| echo 'Job failed...'" .Values.manifestManager.staging }}
 
               echo "Install finished..."
 

--- a/library/common/templates/lib/util/_manifest_manager.tpl
+++ b/library/common/templates/lib/util/_manifest_manager.tpl
@@ -77,10 +77,10 @@ spec:
               touch /tmp/healthy
               echo "Installing manifests..."
               {{- $branch := "manifests" -}}
-              {{- $handleErr := "&& echo 'Job succeeded...'" -}}
+              {{- $handleErr := "|| echo 'Job succeeded...'" -}}
               {{- if .Values.manifestManager.staging -}}
                 {{- $branch = "staging" -}}
-                {{- $handleErr = "|| echo 'Job failed...'" -}}
+                {{- $handleErr = "&& echo 'Job failed...'" -}}
               {{- end }}
 
               kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ $branch }} || \

--- a/library/common/templates/lib/util/_manifest_manager.tpl
+++ b/library/common/templates/lib/util/_manifest_manager.tpl
@@ -76,11 +76,15 @@ spec:
               /bin/sh <<'EOF'
               touch /tmp/healthy
               echo "Installing manifests..."
-              {{ $branch := ternary "staging" "manifests" .Values.manifestManager.staging }}
+              {{- $branch := "manifests" -}}
+              {{- $handleErr := "&& echo 'Job succeeded...'" -}}
+              {{- if .Values.manifestManager.staging -}}
+                {{- $branch = "staging" -}}
+                {{- $handleErr = "|| echo 'Job failed...'" -}}
+              {{- end }}
 
               kubectl apply --server-side --force-conflicts --grace-period 30 --v=4 -k https://github.com/truecharts/manifests/{{ $branch }} || \
-              kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ $branch }} \
-              {{ ternary "&& echo 'Job succeeded...'" "|| echo 'Job failed...'" .Values.manifestManager.staging }}
+              kubectl apply --server-side --force-conflicts --grace-period 30 -k https://github.com/truecharts/manifests/{{ $branch }} {{ $handleErr }}
 
               echo "Install finished..."
 

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -26,7 +26,7 @@ fallbackDefaults:
   # -- Default Retain PVC
   pvcRetain: false
   # -- Default PVC Size
-  pvcSize: 1Gi
+  pvcSize: 100Gi
   # -- Default VCT Size
   vctSize: 100Gi
   # -- Default PVC/VCT Access Modes


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  https://github.com/truecharts/charts/issues/8382

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
