### PR TITLE
fix(codeserver): don't try to mount a volume if it's target on a specific container

### DIFF
--- a/library/common-test/tests/addons/codeserver_test.yaml
+++ b/library/common-test/tests/addons/codeserver_test.yaml
@@ -104,3 +104,68 @@ tests:
         equal:
           path: metadata.name
           value: release-name-common-test
+
+  - it: addon enabled should pass and mount volume with targetSelector on other container only
+    set:
+      workload: &workload
+        main:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              main:
+                enabled: true
+                primary: true
+      persistence:
+        data:
+          enabled: true
+          type: emptyDir
+          targetSelector:
+            main:
+              main:
+                mountPath: /data
+                readOnly: true
+        data2:
+          enabled: true
+          type: emptyDir
+          mountPath: /some/path
+          targetSelector:
+            main:
+              main:
+                readOnly: false
+      addons:
+        codeserver:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: &DeploymentDocument 0
+        isKind:
+          of: Deployment
+      - documentIndex: *DeploymentDocument
+        equal:
+          path: metadata.name
+          value: release-name-common-test
+      - documentIndex: *DeploymentDocument
+        equal:
+          path: spec.template.spec.containers[1].name
+          value: release-name-common-test
+      - documentIndex: *DeploymentDocument
+        equal:
+          path: spec.template.spec.containers[0].name
+          value: release-name-common-test-codeserver
+      - documentIndex: *DeploymentDocument
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /data
+            name: data
+            readOnly: true
+      - documentIndex: *DeploymentDocument
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /some/path
+            name: data2
+            readOnly: false

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.6.6
+version: 12.6.7

--- a/library/common/templates/lib/container/_volumeMounts.tpl
+++ b/library/common/templates/lib/container/_volumeMounts.tpl
@@ -19,7 +19,7 @@ objectData: The object data to be used to render the container.
   {{- range $key := $keys -}}
     {{- range $persistenceName, $persistenceValues := (get $rootCtx.Values $key) -}}
       {{- if $persistenceValues.enabled -}}
-        {{/* Don't try to mount configmap/sercet to codeserver */}}
+        {{/* Dont try to mount configmap/sercet to codeserver */}}
         {{- if not (and (eq $objectData.shortName "codeserver") (mustHas $persistenceValues.type $codeServerIgnoredTypes)) -}}
           {{- $volMount := (fromJson (include "tc.v1.common.lib.container.volumeMount.isSelected" (dict "persistenceName" $persistenceName "persistenceValues" $persistenceValues "objectData" $objectData "key" $key))) -}}
           {{- if $volMount -}}

--- a/library/common/templates/lib/container/_volumeMounts.tpl
+++ b/library/common/templates/lib/container/_volumeMounts.tpl
@@ -99,7 +99,7 @@ objectData: The object data to be used to render the container.
       {{- end -}}
 
       {{/* If container is selected */}}
-      {{- if or (mustHas $objectData.shortName ($selectorValues | keys)) (eq $objectData.shortName "codeserver") -}}
+      {{- if or (mustHas $objectData.shortName ($selectorValues | keys)) -}}
         {{/* Merge with values that might be set for the specific container */}}
         {{- $volMount = mustMergeOverwrite $volMount (get $selectorValues $objectData.shortName) -}}
         {{- $return = true -}}

--- a/library/common/templates/lib/container/_volumeMounts.tpl
+++ b/library/common/templates/lib/container/_volumeMounts.tpl
@@ -10,6 +10,7 @@ objectData: The object data to be used to render the container.
 
   {{- $volMounts := list -}}
 
+  {{- $codeServerIgnoredTypes := (list "configmap" "secret") -}}
   {{- $keys := (list "persistence") -}}
   {{- if eq $objectData.podType "StatefulSet" -}}
     {{- $keys = mustAppend $keys "volumeClaimTemplates" -}}
@@ -18,9 +19,12 @@ objectData: The object data to be used to render the container.
   {{- range $key := $keys -}}
     {{- range $persistenceName, $persistenceValues := (get $rootCtx.Values $key) -}}
       {{- if $persistenceValues.enabled -}}
-        {{- $volMount := (fromJson (include "tc.v1.common.lib.container.volumeMount.isSelected" (dict "persistenceName" $persistenceName "persistenceValues" $persistenceValues "objectData" $objectData "key" $key))) -}}
-        {{- if $volMount -}}
-          {{- $volMounts = mustAppend $volMounts $volMount -}}
+        {{/* Don't try to mount configmap/sercet to codeserver */}}
+        {{- if not (and (eq $objectData.shortName "codeserver") (mustHas $persistenceValues.type $codeServerIgnoredTypes)) -}}
+          {{- $volMount := (fromJson (include "tc.v1.common.lib.container.volumeMount.isSelected" (dict "persistenceName" $persistenceName "persistenceValues" $persistenceValues "objectData" $objectData "key" $key))) -}}
+          {{- if $volMount -}}
+            {{- $volMounts = mustAppend $volMounts $volMount -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}
@@ -99,9 +103,13 @@ objectData: The object data to be used to render the container.
       {{- end -}}
 
       {{/* If container is selected */}}
-      {{- if or (mustHas $objectData.shortName ($selectorValues | keys)) -}}
+      {{- if or (mustHas $objectData.shortName ($selectorValues | keys)) (eq $objectData.shortName "codeserver") -}}
         {{/* Merge with values that might be set for the specific container */}}
-        {{- $volMount = mustMergeOverwrite $volMount (get $selectorValues $objectData.shortName) -}}
+        {{- $fetchedSelectorValues := (get $selectorValues $objectData.shortName) -}}
+        {{- if and (eq $objectData.shortName "codeserver") (not $fetchedSelectorValues) -}}
+          {{- $fetchedSelectorValues = (get $selectorValues ($selectorValues | keys | first)) -}}
+        {{- end -}}
+        {{- $volMount = mustMergeOverwrite $volMount $fetchedSelectorValues -}}
         {{- $return = true -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  https://github.com/truecharts/charts/issues/8694

When there is a `targetSelector` defined, don't try to mount this volume to codeserver. As it's most likely a configmap/secret or a volume only relevant to a specific container

eg:
```yaml
persistence:
  init:
    enabled: true
    type: configmap
    objectName: init
    mountPath: "/config/init"
    defaultMode: "0777"
    readOnly: true
    targetSelector:
      main:
        init: {}
```
But the caveat is that also this wont be mounted:
```yaml
persistence:
  vol:
    enabled: true
    type: emptyDir
    mountPath: "/config/init"
    targetSelector:
      main:
        main: {}
```

TL;DR only volumes without a selector or a selector with `targetSelectAll` will be mounted to codeserver.

Not sure what we could do on scale GUI to make this more flexible. Needs more thought.
But this is a quick fix for now.


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
