### PR TITLE
feat(common): add support for cnpg cluster hibernation without using annotations

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~12.6.0
+  version: ~12.7.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.6.9
+version: 12.7.0

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -15,14 +15,16 @@ apiVersion: {{ include "tc.v1.common.capabilities.cnpg.cluster.apiVersion" $ }}
 kind: Cluster
 metadata:
   name: {{ $cnpgClusterName }}
-  {{- $labels := (mustMerge ($cnpgClusterLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
-  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
+  {{- $labels := (mustMerge ($cnpgClusterLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) }}
   labels:
+    cnpg.io/reload: "on"
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
     {{- . | nindent 4 }}
   {{- end }}
-  {{- $annotations := (mustMerge ($cnpgClusterAnnotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $ | fromYaml)) -}}
-  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "annotations" $annotations) | trim) }}
+  {{- $annotations := (mustMerge ($cnpgClusterAnnotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $ | fromYaml)) }}
   annotations:
+    cnpg.io/hibernation: {{ if $values.hibernate }}"on"{{ else }}"off"{{ end }}
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "annotations" $annotations) | trim) }}
     {{- . | nindent 4 }}
   {{- end }}
 spec:
@@ -64,7 +66,7 @@ spec:
 
   nodeMaintenanceWindow:
     inProgress: false
-    reusePVC: on
+    reusePVC: true
 
   postgresql:
     {{- tpl ( $values.postgresql | toYaml ) $ | nindent 4 }}

--- a/library/common/templates/class/_cnpgPooler.tpl
+++ b/library/common/templates/class/_cnpgPooler.tpl
@@ -21,7 +21,7 @@ spec:
   cluster:
     name: {{ $cnpgClusterName }}
 
-  instances: {{ $values.pooler.instances | default 2 }}
+  instances: {{ if $values.hibernate}}0{{ else }}{{ $values.pooler.instances | default 2 }}{{ end }}
   type: {{ $values.pooler.type }}
   pgbouncer:
     poolMode: session

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -705,6 +705,8 @@ cnpg:
   main:
     enabled: false
     primary: true
+    # -- Puts the cnpg cluster in hibernation mode
+    hibernate: false
     # -- number of instances for both postgres and pgbouncer
     instances: 2
     database: "app"
@@ -724,6 +726,7 @@ cnpg:
     storage:
       size: "256Gi"
       walsize: "256Gi"
+    # -- Gets scaled to 0 if hibernation is true
     pooler:
       instances: 2
     # -- set to enable prometheus metrics


### PR DESCRIPTION
**Description**
cluster hibernation is a good way to get CNPG to scale down to 0 cleanly.
This might(!) be a potential solution for fixing the broken stop button on SCALE as well, but that's not fully clear as of yet.

This also scales down the poolers to 0 as well. To ensure nothing remains active.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
