### PR TITLE
feat(common): Add .global.stopAll option to stop all on native Helm

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~12.7.0
+  version: ~12.8.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.7.0
+version: 12.8.0

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -23,7 +23,7 @@ metadata:
   {{- end }}
   {{- $annotations := (mustMerge ($cnpgClusterAnnotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $ | fromYaml)) }}
   annotations:
-    cnpg.io/hibernation: {{ if $values.hibernate }}"on"{{ else }}"off"{{ end }}
+    cnpg.io/hibernation: {{ if or $values.hibernate $.Values.global.stopAll }}"on"{{ else }}"off"{{ end }}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "annotations" $annotations) | trim) }}
     {{- . | nindent 4 }}
   {{- end }}

--- a/library/common/templates/class/_cnpgPooler.tpl
+++ b/library/common/templates/class/_cnpgPooler.tpl
@@ -21,7 +21,7 @@ spec:
   cluster:
     name: {{ $cnpgClusterName }}
 
-  instances: {{ if $values.hibernate}}0{{ else }}{{ $values.pooler.instances | default 2 }}{{ end }}
+  instances: {{ if or $values.hibernate $.Values.global.stopAll }}0{{ else }}{{ $values.pooler.instances | default 2 }}{{ end }}
   type: {{ $values.pooler.type }}
   pgbouncer:
     poolMode: session

--- a/library/common/templates/lib/pod/_nodeSelector.tpl
+++ b/library/common/templates/lib/pod/_nodeSelector.tpl
@@ -20,10 +20,14 @@ objectData: The object data to be used to render the Pod.
     {{- $selectors = . -}}
   {{- end -}}
 
-  {{- range $k, $v := $selectors -}}
-    {{- if not $v -}}
-      {{- fail (printf "Expected non-empty value on <nodeSelector> [%s] key." $k) -}}
-    {{- end }}
+  {{-  if and $rootCtx.Values.global.stopAll ( eq $objectData.type "DaemonSet" ) -}}
+"non-existing": "true"
+  {{- else -}}
+    {{- range $k, $v := $selectors -}}
+      {{- if not $v -}}
+        {{- fail (printf "Expected non-empty value on <nodeSelector> [%s] key." $k) -}}
+      {{- end }}
 {{ $k }}: {{ tpl $v $rootCtx }}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/workload/_cronjobSpec.tpl
+++ b/library/common/templates/lib/workload/_cronjobSpec.tpl
@@ -20,6 +20,7 @@ concurrencyPolicy: {{ $objectData.concurrencyPolicy | default "Forbid" }}
 failedJobsHistoryLimit: {{ $objectData.failedJobsHistoryLimit | default 1 }}
 successfulJobsHistoryLimit: {{ $objectData.successfulJobsHistoryLimit | default 3 }}
 startingDeadlineSeconds: {{ $objectData.startingDeadlineSeconds | default 600 }}
+suspend: {{ if $rootCtx.global.stopAll }}true {{ else }}{{ $objectData.suspend | default false }}{{ end }}
 jobTemplate:
   spec:
     {{- include "tc.v1.common.lib.workload.jobSpec" (dict "rootCtx" $rootCtx "objectData" $objectData) | indent 4 }}

--- a/library/common/templates/lib/workload/_cronjobSpec.tpl
+++ b/library/common/templates/lib/workload/_cronjobSpec.tpl
@@ -20,7 +20,7 @@ concurrencyPolicy: {{ $objectData.concurrencyPolicy | default "Forbid" }}
 failedJobsHistoryLimit: {{ $objectData.failedJobsHistoryLimit | default 1 }}
 successfulJobsHistoryLimit: {{ $objectData.successfulJobsHistoryLimit | default 3 }}
 startingDeadlineSeconds: {{ $objectData.startingDeadlineSeconds | default 600 }}
-suspend: {{ if $rootCtx.global.stopAll }}true {{ else }}{{ $objectData.suspend | default false }}{{ end }}
+suspend: {{ if $rootCtx.Values.global.stopAll }}true {{ else }}{{ $objectData.suspend | default false }}{{ end }}
 jobTemplate:
   spec:
     {{- include "tc.v1.common.lib.workload.jobSpec" (dict "rootCtx" $rootCtx "objectData" $objectData) | indent 4 }}

--- a/library/common/templates/lib/workload/_deployementSpec.tpl
+++ b/library/common/templates/lib/workload/_deployementSpec.tpl
@@ -11,7 +11,7 @@ objectData:
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $strategy := $objectData.strategy | default "Recreate" }}
-replicas: {{ $objectData.replicas | default 1 }}
+replicas: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 strategy:
   type: {{ $strategy }}

--- a/library/common/templates/lib/workload/_deployementSpec.tpl
+++ b/library/common/templates/lib/workload/_deployementSpec.tpl
@@ -11,7 +11,7 @@ objectData:
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $strategy := $objectData.strategy | default "Recreate" }}
-replicas: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
+replicas: {{ if $rootCtx.Values.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 strategy:
   type: {{ $strategy }}

--- a/library/common/templates/lib/workload/_jobSpec.tpl
+++ b/library/common/templates/lib/workload/_jobSpec.tpl
@@ -16,7 +16,7 @@ objectData:
 backoffLimit: {{ $objectData.backoffLimit | default 5 }}
 completionMode: {{ $objectData.completionMode | default "NonIndexed" }}
 completions: {{ $objectData.completions | default nil }}
-parallelism: {{ $objectData.parallelism | default 1 }}
+parallelism: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.parallelism | default 1 }}{{ end }}
 ttlSecondsAfterFinished: {{ $objectData.ttlSecondsAfterFinished | default 120 }}
   {{- with $objectData.activeDeadlineSeconds }}
 activeDeadlineSeconds: {{ . }}

--- a/library/common/templates/lib/workload/_jobSpec.tpl
+++ b/library/common/templates/lib/workload/_jobSpec.tpl
@@ -16,7 +16,7 @@ objectData:
 backoffLimit: {{ $objectData.backoffLimit | default 5 }}
 completionMode: {{ $objectData.completionMode | default "NonIndexed" }}
 completions: {{ $objectData.completions | default nil }}
-parallelism: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.parallelism | default 1 }}{{ end }}
+parallelism: {{ if $rootCtx.Values.global.stopAll }}0{{ else }}{{ $objectData.parallelism | default 1 }}{{ end }}
 ttlSecondsAfterFinished: {{ $objectData.ttlSecondsAfterFinished | default 120 }}
   {{- with $objectData.activeDeadlineSeconds }}
 activeDeadlineSeconds: {{ . }}

--- a/library/common/templates/lib/workload/_statefulsettSpec.tpl
+++ b/library/common/templates/lib/workload/_statefulsettSpec.tpl
@@ -11,7 +11,7 @@ objectData:
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $strategy := $objectData.strategy | default "RollingUpdate" }}
-replicas: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
+replicas: {{ if $rootCtx.Values.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 serviceName: {{ $objectData.name }}
 updateStrategy:

--- a/library/common/templates/lib/workload/_statefulsettSpec.tpl
+++ b/library/common/templates/lib/workload/_statefulsettSpec.tpl
@@ -11,7 +11,7 @@ objectData:
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $strategy := $objectData.strategy | default "RollingUpdate" }}
-replicas: {{ $objectData.replicas | default 1 }}
+replicas: {{ if $rootCtx.global.stopAll }}0{{ else }}{{ $objectData.replicas | default 1 }}{{ end }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 serviceName: {{ $objectData.name }}
 updateStrategy:

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -11,7 +11,7 @@ global:
   # -- Minimum nodePort value
   minNodePort: 9000
   # -- Enable to stop most pods and containers including cnpg
-  # does not include (cron)jobs, daemonsets and other objects without replicas
+  # does not include stand-alone pods
   stopAll: false
 
 fallbackDefaults:

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -10,6 +10,9 @@ global:
   addTraefikAnnotations: true
   # -- Minimum nodePort value
   minNodePort: 9000
+  # -- Enable to stop most pods and containers including cnpg
+  # does not include (cron)jobs, daemonsets and other objects without replicas
+  stopAll: false
 
 fallbackDefaults:
   # -- Define a storageClassName that will be used for all PVCs


### PR DESCRIPTION
**Description**
This implements a SCALE stop-button *like* experience on native helm.

This one actually works, in stark contrast to the iX stop-button attempt:
- It uses helm, so helm edits don't magically start apps again (iX stop button messes with objects managed by helm)
- It actually stops daemonsets (by only scheduling them on non-existing nodes)
- It actually prevents (cron)jobs from running
- It hibernates cnpg clusters
- It can be expanded to as many custom objects as wel like/need in the future

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
Can be abstracted away a bit (by putting an include in-between) to also stop things prior to using the SCALE stop button, when iX ever exposes that option.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
