### PR TITLE
feat(common): implement support for registering and verifying dynamic operator namespaces

### DIFF
--- a/.github/workflows/common_library_tests.yaml
+++ b/.github/workflows/common_library_tests.yaml
@@ -131,6 +131,7 @@ jobs:
           - cnpg-multi-values.yaml
           - manifest-values.yaml
           - stagingmanifest-values.yaml
+          - register-operator-values.yaml
 
     steps:
       - name: Checkout
@@ -247,6 +248,7 @@ jobs:
           - extra-containers-values.yaml
           - rbac-values.yaml
           - networkPolicy-values.yaml
+          - register-operator-values.yaml
           # Runs as root, so test results become obviously red
           # - codeserver-values.yaml
           # - netshoot-values.yaml

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~12.8.0
+  version: ~12.9.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/ci/register-operator-values.yaml
+++ b/library/common-test/ci/register-operator-values.yaml
@@ -1,0 +1,44 @@
+service:
+  main:
+    enabled: true
+    primary: true
+    ports:
+      main:
+        enabled: true
+        primary: true
+        protocol: http
+        port: 8080
+
+workload:
+  main:
+    enabled: true
+    primary: true
+    type: Deployment
+    podSpec:
+      containers:
+        main:
+          enabled: true
+          primary: true
+          args:
+            - --port
+            - "8080"
+          probes:
+            liveness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            readiness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            startup:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+
+args:
+  - --port
+  - '8080'
+
+operator:
+  register: true

--- a/library/common-test/default-values.yaml
+++ b/library/common-test/default-values.yaml
@@ -1,3 +1,6 @@
+global:
+  createTCNamespace: true
+
 workload:
   main:
     enabled: true

--- a/library/common-test/tests/addons/codeserver_test.yaml
+++ b/library/common-test/tests/addons/codeserver_test.yaml
@@ -61,16 +61,7 @@ tests:
 
   - it: addon enabled should pass without other service
     set:
-      workload: &workload
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: false
@@ -107,16 +98,7 @@ tests:
 
   - it: addon enabled should pass and mount volume with targetSelector on other container only
     set:
-      workload: &workload
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       persistence:
         data:
           enabled: true

--- a/library/common-test/tests/addons/netshoot_test.yaml
+++ b/library/common-test/tests/addons/netshoot_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: addon enabled should pass
     set:
-      workload: &workload
+      workload:
         main:
           enabled: true
           primary: true

--- a/library/common-test/tests/addons/vpn_test.yaml
+++ b/library/common-test/tests/addons/vpn_test.yaml
@@ -153,16 +153,7 @@ tests:
             down: |
               echo "down"
               echo "done"
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true
@@ -279,16 +270,7 @@ tests:
         vpn:
           type: gluetun
           existingSecret: existing-secret
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true
@@ -347,16 +329,7 @@ tests:
         vpn:
           type: gluetun
           configFile: /path/to/file
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true
@@ -412,16 +385,7 @@ tests:
         vpn:
           type: gluetun
           configFolder: /path/to/folder
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true
@@ -480,16 +444,7 @@ tests:
           env:
             key: value
             key1: value1
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
     asserts:
       - hasDocuments:
           count: 1
@@ -591,16 +546,7 @@ tests:
         vpn:
           type: openvpn
           configFile: /path/to/file
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true
@@ -656,16 +602,7 @@ tests:
         vpn:
           type: wireguard
           configFile: /path/to/file
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: Deployment
-          podSpec:
-            containers:
-              main:
-                enabled: true
-                primary: true
+      workload: *workload
       service:
         main:
           enabled: true

--- a/library/common-test/tests/configmap/metadata_test.yaml
+++ b/library/common-test/tests/configmap/metadata_test.yaml
@@ -54,3 +54,20 @@ tests:
             g_label2: global_label2
             label1: label1
             label2: label2
+      - documentIndex: *configMapDoc
+        isNull:
+          path: metadata.namespace
+
+  - it: should pass with configmap created with namespace
+    set:
+      configmap:
+        my-configmap1:
+          enabled: true
+          namespace: some-namespace
+          data:
+            foo: bar
+    asserts:
+      - documentIndex: *configMapDoc
+        equal:
+          path: metadata.namespace
+          value: some-namespace

--- a/library/common-test/tests/configmap/metadata_test.yaml
+++ b/library/common-test/tests/configmap/metadata_test.yaml
@@ -71,3 +71,18 @@ tests:
         equal:
           path: metadata.namespace
           value: some-namespace
+
+  - it: should pass with configmap created with namespace from tpl
+    set:
+      namespace: some-namespace
+      configmap:
+        my-configmap1:
+          enabled: true
+          namespace: "{{ .Values.namespace }}"
+          data:
+            foo: bar
+    asserts:
+      - documentIndex: *configMapDoc
+        equal:
+          path: metadata.namespace
+          value: some-namespace

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -4,6 +4,8 @@ templates:
 tests:
   - it: should pass with defaults
     set:
+      global:
+        createTCNamespace: true
       service:
         main:
           enabled: true
@@ -20,11 +22,21 @@ tests:
                 enabled: true
     asserts:
       - hasDocuments:
-          count: 2
-      - documentIndex: &deploymentDoc 0
+          count: 3
+      - documentIndex: &namespaceDoc 0
+        isKind:
+          of: Namespace
+      - documentIndex: *namespaceDoc
+        equal:
+          path: metadata.name
+          value: tc-system
+      - documentIndex: *namespaceDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: &deploymentDoc 1
         isKind:
           of: Deployment
-      - documentIndex: &serviceDoc 1
+      - documentIndex: &serviceDoc 2
         isKind:
           of: Service
       - documentIndex: *serviceDoc

--- a/library/common-test/tests/operator/operator_test.yaml
+++ b/library/common-test/tests/operator/operator_test.yaml
@@ -1,0 +1,32 @@
+suite: operator configmap data test
+templates:
+  - common.yaml
+release:
+  namespace: &namespace test-namespace
+chart:
+  version: &version v9.9.9
+tests:
+  - it: should pass with key-value data
+    set:
+      global:
+        createTCNamespace: true
+      operator:
+        register: true
+    asserts:
+      - documentIndex: &configmapDoc 1
+        isKind:
+          of: ConfigMap
+      - documentIndex: *configmapDoc
+        equal:
+          path: metadata.name
+          value: common-test
+      - documentIndex: *configmapDoc
+        equal:
+          path: metadata.namespace
+          value: tc-system
+      - documentIndex: *configmapDoc
+        equal:
+          path: data
+          value:
+            namespace: *namespace
+            version: *version

--- a/library/common-test/tests/operator/operator_test.yaml
+++ b/library/common-test/tests/operator/operator_test.yaml
@@ -30,3 +30,16 @@ tests:
           value:
             namespace: *namespace
             version: *version
+
+  - it: should fail without additional operators installed
+    set:
+      global:
+        createTCNamespace: true
+      operator:
+        register: true
+        verify:
+          additionalOperators:
+            - some-operator
+    asserts:
+      - failedTemplate:
+          errorMessage: Operator [some-operator] needs to be installed

--- a/library/common-test/tests/operator/operator_test.yaml
+++ b/library/common-test/tests/operator/operator_test.yaml
@@ -38,6 +38,7 @@ tests:
       operator:
         register: true
         verify:
+          enabled: true
           additionalOperators:
             - some-operator
     asserts:

--- a/library/common-test/tests/secret/metadata_test.yaml
+++ b/library/common-test/tests/secret/metadata_test.yaml
@@ -54,3 +54,20 @@ tests:
             g_label2: global_label2
             label1: label1
             label2: label2
+      - documentIndex: *secretDoc
+        isNull:
+          path: metadata.namespace
+
+  - it: should pass with secret created with namespace
+    set:
+      secret:
+        my-secret1:
+          enabled: true
+          namespace: some-namespace
+          data:
+            foo: bar
+    asserts:
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.namespace
+          value: some-namespace

--- a/library/common-test/tests/secret/metadata_test.yaml
+++ b/library/common-test/tests/secret/metadata_test.yaml
@@ -71,3 +71,18 @@ tests:
         equal:
           path: metadata.namespace
           value: some-namespace
+
+  - it: should pass with secret created with namespace from tpl
+    set:
+      namespace: some-namespace
+      secret:
+        my-secret1:
+          enabled: true
+          namespace: "{{ .Values.namespace }}"
+          data:
+            foo: bar
+    asserts:
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.namespace
+          value: some-namespace

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -2,6 +2,9 @@
 # This is to have common test cases without getting affected
 # by any default values.
 
+global:
+  createTCNamespace: false
+
 workload:
   main:
     enabled: false

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.8.1
+version: 12.9.0

--- a/library/common/templates/class/_configmap.tpl
+++ b/library/common/templates/class/_configmap.tpl
@@ -8,6 +8,7 @@ objectData:
   labels: The labels of the configmap.
   annotations: The annotations of the configmap.
   data: The data of the configmap.
+  namespace: The namespace of the configmap. (Optional)
 */}}
 
 {{- define "tc.v1.common.class.configmap" -}}
@@ -28,6 +29,9 @@ metadata:
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "annotations" $annotations) | trim) }}
   annotations:
     {{- . | nindent 4 }}
+  {{- end -}}
+  {{- with $objectData.namespace }}
+  namespace: {{ tpl . $rootCtx }}
   {{- end }}
 data:
   {{- tpl (toYaml $objectData.data) $rootCtx | nindent 2 }}

--- a/library/common/templates/class/_secret.tpl
+++ b/library/common/templates/class/_secret.tpl
@@ -9,6 +9,7 @@ objectData:
   annotations: The annotations of the secret.
   type: The type of the secret.
   data: The data of the secret.
+  namespace: The namespace of the secret. (Optional)
 */}}
 
 {{- define "tc.v1.common.class.secret" -}}
@@ -39,6 +40,9 @@ metadata:
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "annotations" $annotations) | trim) }}
   annotations:
     {{- . | nindent 4 }}
+  {{- end -}}
+  {{- with $objectData.namespace }}
+  namespace: {{ tpl . $rootCtx }}
   {{- end -}}
   {{- if (mustHas $objectData.type (list "certificate" "imagePullSecret")) }}
 data:

--- a/library/common/templates/lib/util/_register_operator.tpl
+++ b/library/common/templates/lib/util/_register_operator.tpl
@@ -1,8 +1,8 @@
 {{- define "tc.v1.common.lib.util.operator.register" -}}
 {{- if .Values.operator.register }}
-{{ $operator := lookup "v1" "ConfigMap" "tc-system" {{ $.Chart.Name }} }}
+{{ $operator := lookup "v1" "ConfigMap" "tc-system" $.Chart.Name }}
 {{ if $operator }}
-  {{- fail ( printf "You cannot install 2 copies of the same operator..." ) }}
+  {{- fail "You cannot install the same operator twice..." }}
 {{ end }}
 ---
 apiVersion: v1

--- a/library/common/templates/lib/util/_register_operator.tpl
+++ b/library/common/templates/lib/util/_register_operator.tpl
@@ -1,0 +1,25 @@
+{{- define "tc.v1.common.lib.util.operator.register" -}}
+{{- if .Values.operator.register }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Chart.Name }}
+  {{- $labels := (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml) -}}
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
+  labels:
+    {{- . | nindent 4 }}
+  {{- end -}}
+  {{- $annotations := (include "tc.v1.common.lib.metadata.allAnnotations" $ | fromYaml) -}}
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "annotations" $annotations) | trim) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+  namespace: tc-system
+data:
+  {{/* The namespace the operator is installed in */}}
+  namespace: {{ $.Release.Namespace }}
+  {{/* The version of the installed operator */}}
+  version: {{ $.Chart.Version }}
+{{- end }}
+{{- end -}}

--- a/library/common/templates/lib/util/_register_operator.tpl
+++ b/library/common/templates/lib/util/_register_operator.tpl
@@ -1,29 +1,15 @@
 {{- define "tc.v1.common.lib.util.operator.register" -}}
-{{- if .Values.operator.register }}
-{{ $operator := lookup "v1" "ConfigMap" "tc-system" $.Chart.Name }}
-{{ if $operator }}
-  {{- fail "You cannot install the same operator twice..." }}
-{{ end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ $.Chart.Name }}
-  {{- $labels := (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml) -}}
-  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
-  labels:
-    {{- . | nindent 4 }}
+  {{- if .Values.operator.register -}}
+    {{- with (lookup "v1" "ConfigMap" "tc-system" $.Chart.Name) -}}
+      {{- fail "You cannot install the same operator twice..." -}}
+    {{- end -}}
+
+    {{- $objectData := (dict  "name"      $.Chart.Name
+                              "namespace" "tc-system"
+                              "data"      (dict "namespace" $.Release.Namespace
+                                                "version"   $.Chart.Version)) -}}
+    {{/* data.namespace   - The namespace the operator is installed in */}}
+    {{/* data.version     - The version of the installed operator */}}
+    {{- include "tc.v1.common.class.configmap" (dict "rootCtx" $ "objectData" $objectData) -}}
   {{- end -}}
-  {{- $annotations := (include "tc.v1.common.lib.metadata.allAnnotations" $ | fromYaml) -}}
-  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "annotations" $annotations) | trim) }}
-  annotations:
-    {{- . | nindent 4 }}
-  {{- end }}
-  namespace: tc-system
-data:
-  {{/* The namespace the operator is installed in */}}
-  namespace: {{ $.Release.Namespace }}
-  {{/* The version of the installed operator */}}
-  version: {{ $.Chart.Version }}
-{{- end }}
 {{- end -}}

--- a/library/common/templates/lib/util/_register_operator.tpl
+++ b/library/common/templates/lib/util/_register_operator.tpl
@@ -1,5 +1,9 @@
 {{- define "tc.v1.common.lib.util.operator.register" -}}
 {{- if .Values.operator.register }}
+{{ $operator := lookup "v1" "ConfigMap" "tc-system" {{ $.Chart.Name }} }}
+{{ if $operator }}
+  {{- fail ( printf "You cannot install 2 copies of the same operator..." ) }}
+{{ end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/library/common/templates/lib/util/_register_operator.tpl
+++ b/library/common/templates/lib/util/_register_operator.tpl
@@ -1,7 +1,7 @@
 {{- define "tc.v1.common.lib.util.operator.register" -}}
   {{- if .Values.operator.register -}}
     {{- with (lookup "v1" "ConfigMap" "tc-system" $.Chart.Name) -}}
-      {{- fail "You cannot install the same operator twice..." -}}
+      {{- fail (printf "You cannot install the [%s] operator twice..." $.Chart.Name) -}}
     {{- end -}}
 
     {{- $objectData := (dict  "name"      $.Chart.Name

--- a/library/common/templates/lib/util/_tc_namespace.tpl
+++ b/library/common/templates/lib/util/_tc_namespace.tpl
@@ -1,5 +1,7 @@
 {{- define "tc.v1.common.lib.util.tcnamespace" -}}
-  {{- if $.Values.global.createTCNamespace }}
+  {{- if $.Values.global.createTCNamespace -}}
+    {{/* Only create it if it does not exist */}}
+    {{- if not (lookup "v1" "Namespace" "tc-system" "") }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -7,5 +9,6 @@ metadata:
   name: tc-system
   annotations:
     "helm.sh/resource-policy": keep
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/util/_tcnamespace.tpl
+++ b/library/common/templates/lib/util/_tcnamespace.tpl
@@ -1,0 +1,9 @@
+{{- define "tc.v1.common.lib.util.tcnamespace" -}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tc-system
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- end -}}

--- a/library/common/templates/lib/util/_tcnamespace.tpl
+++ b/library/common/templates/lib/util/_tcnamespace.tpl
@@ -1,4 +1,5 @@
 {{- define "tc.v1.common.lib.util.tcnamespace" -}}
+  {{- if $.Values.global.createTCNamespace }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -6,4 +7,5 @@ metadata:
   name: tc-system
   annotations:
     "helm.sh/resource-policy": keep
+  {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/util/_verify_operator.tpl
+++ b/library/common/templates/lib/util/_verify_operator.tpl
@@ -1,12 +1,11 @@
 {{- define "tc.v1.common.lib.util.operator.verify" -}}
-{{- if .Values.operator.verify.enabled }}
+  {{- if .Values.operator.verify.enabled -}}
 
-{{- range .Values.operator.verify.additionalOperators -}}
-  {{ $operator := lookup "v1" "ConfigMap" "tc-system" . }}
-  {{ if not $operator }}
-    {{- fail ( printf "The following Operator needs to be installed: %s" . ) }}
-  {{ end }}
-{{ end }}
+    {{- range .Values.operator.verify.additionalOperators -}}
+      {{- if not (lookup "v1" "ConfigMap" "tc-system" .) -}}
+        {{- fail (printf "Operator [%s] needs to be installed" . ) -}}
+      {{- end -}}
+    {{- end -}}
 
-{{- end }}
+  {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/util/_verify_operator.tpl
+++ b/library/common/templates/lib/util/_verify_operator.tpl
@@ -1,0 +1,13 @@
+{{- define "tc.v1.common.lib.util.operator.verify" -}}
+{{- if .Values.operator.verify.enabled }}
+
+{{- $rootCtx := $ }}
+{{- range .Values.operator.verify.additionalOperators -}}
+  {{ $operator := lookup "v1" "ConfigMap" "tc-system" . }}
+  {{ if not $operator }}
+    {{- fail ( printf "The following Operator needs to be installed: %s" . ) }}
+  {{ end }}
+{{ end }}
+
+{{- end }}
+{{- end -}}

--- a/library/common/templates/lib/util/_verify_operator.tpl
+++ b/library/common/templates/lib/util/_verify_operator.tpl
@@ -1,7 +1,6 @@
 {{- define "tc.v1.common.lib.util.operator.verify" -}}
 {{- if .Values.operator.verify.enabled }}
 
-{{- $rootCtx := $ }}
 {{- range .Values.operator.verify.additionalOperators -}}
   {{ $operator := lookup "v1" "ConfigMap" "tc-system" . }}
   {{ if not $operator }}

--- a/library/common/templates/loader/_init.tpl
+++ b/library/common/templates/loader/_init.tpl
@@ -1,10 +1,11 @@
 {{/* Initialiaze values of the chart */}}
 {{- define "tc.v1.common.loader.init" -}}
-  {{/* create tc-system namespace */}}
-  {{- include "tc.v1.common.lib.util.tcnamespace" . }}
 
   {{/* Merge chart values and the common chart defaults */}}
   {{- include "tc.v1.common.values.init" . -}}
+
+  {{/* Create tc-system namespace */}}
+  {{- include "tc.v1.common.lib.util.tcnamespace" . -}}
 
   {{/* Parse lists and append to values */}}
   {{- include "tc.v1.common.loader.lists" . -}}

--- a/library/common/templates/loader/_init.tpl
+++ b/library/common/templates/loader/_init.tpl
@@ -1,5 +1,7 @@
 {{/* Initialiaze values of the chart */}}
 {{- define "tc.v1.common.loader.init" -}}
+  {{/* create tc-system namespace */}}
+  {{- include "tc.v1.common.lib.util.tcnamespace" . }}
 
   {{/* Merge chart values and the common chart defaults */}}
   {{- include "tc.v1.common.values.init" . -}}
@@ -30,6 +32,12 @@
 
   {{/* Autogenerate solr passwords if needed */}}
   {{- include "tc.v1.common.dependencies.solr.injector" . }}
+
+  {{/* Register Operator if needed */}}
+  {{- include "tc.v1.common.lib.util.operator.register" . }}
+
+  {{/* Verify if required operators are present */}}
+  {{- include "tc.v1.common.lib.util.operator.verify" . }}
 
   {{/* Enable code-server add-on if required */}}
   {{- if .Values.addons.codeserver.enabled }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -558,7 +558,7 @@ metrics:
 operator:
   # -- Adds a configmap in tc-system namespace to register this chart as an operator
   register: false
-  # -- Verified weither required operators for this chart are actually installed and registered
+  # -- Verified wether required operators for this chart are actually installed and registered
   verify:
     enabled: true
     # -- a list of extra operators to check for

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -13,6 +13,8 @@ global:
   # -- Enable to stop most pods and containers including cnpg
   # does not include stand-alone pods
   stopAll: false
+  # -- Creates the tc-system namespace. Used for operator charts
+  createTCNamespace: true
 
 fallbackDefaults:
   # -- Define a storageClassName that will be used for all PVCs

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -552,6 +552,16 @@ metrics:
         #   # list to support adding rules via the SCALE GUI without overwrithing the rules
         #   additionalrules: []
 
+# -- Contains specific settings for helm charts containing or using operators
+operator:
+  # -- Adds a configmap in tc-system namespace to register this chart as an operator
+  register: false
+  # -- Verified weither required operators for this chart are actually installed and registered
+  verify:
+    enabled: true
+    # -- a list of extra operators to check for
+    additionalOperators: []
+
 # -- The common chart supports several add-ons. These can be configured under this key.
 # @default -- See below
 addons:


### PR DESCRIPTION
**Description**
We got requests from iX that they would like us to not side-load operators into namespaces that are not SCALE managed.
This feature limits allows us to use dynamically named namespaces for charts containing operators.

It registers all operators and their namespace using a configmap in the fixed `tc-system` namespace.

This means all operators can use dynamic namespaces (if the operator itself supports that) and don't have to be hotloaded in non-scale namespaces by manifestmanager in the future anymore.

It also moves tc-system namespace creation to common.
This ensures we can also change traefik middleware namespace logic later as well.

On top of this, it also contains logic to prevent duplicate installs of the same operator.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
