### PR TITLE
fix(sysctls): dont add net.ipv4.ip_unprivileged_port_start when hostNet is enabled

### DIFF
--- a/library/common-test/tests/pod/securityContext.yaml
+++ b/library/common-test/tests/pod/securityContext.yaml
@@ -259,7 +259,8 @@ tests:
           value:
             fsGroup: 568
             fsGroupChangePolicy: OnRootMismatch
-            supplementalGroups: []
+            supplementalGroups:
+              - 568
             sysctls: []
 
   - it: should pass with fsGroup 0

--- a/library/common-test/tests/pod/securityContext.yaml
+++ b/library/common-test/tests/pod/securityContext.yaml
@@ -225,6 +225,43 @@ tests:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "443"
 
+  - it: should pass with sysctls net.ipv4.ip_unprivileged_port_start NOT appended with hostnet
+    set:
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            hostNetwork: true
+        workload-name2:
+          enabled: true
+          type: Deployment
+          podSpec: {}
+      service:
+        service-name:
+          enabled: true
+          primary: true
+          type: ClusterIP
+          targetSelector: workload-name2
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 443
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: []
+            sysctls: []
+
   - it: should pass with fsGroup 0
     set:
       securityContext:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.8.1
+version: 12.8.2

--- a/library/common/templates/lib/pod/_podSecurityContext.tpl
+++ b/library/common/templates/lib/pod/_podSecurityContext.tpl
@@ -15,7 +15,7 @@ objectData: The object data to be used to render the Pod.
   {{/* Initialize from the "global" option */}}
   {{- $secContext := mustDeepCopy $rootCtx.Values.securityContext.pod -}}
 
-  {{/* Override with pod's option */}}
+  {{/* Override with pods option */}}
   {{- with $objectData.podSpec.securityContext -}}
     {{- $secContext = mustMergeOverwrite $secContext . -}}
   {{- end -}}
@@ -27,7 +27,7 @@ objectData: The object data to be used to render the Pod.
       {{- if mustHas $objectData.shortName ($GPUValues.targetSelector | keys) -}}
         {{- $gpuAdded = true -}}
       {{- end -}}
-    {{/* If there isn't a selector, but pod is primary */}}
+    {{/* If there is not a selector, but pod is primary */}}
     {{- else if $objectData.primary -}}
       {{- $gpuAdded = true -}}
     {{- end -}}
@@ -66,8 +66,12 @@ objectData: The object data to be used to render the Pod.
   {{- end -}}
 
   {{- $portRange := fromJson (include "tc.v1.common.lib.helpers.securityContext.getPortRange" (dict "rootCtx" $rootCtx "objectData" $objectData)) -}}
-  {{- if and $portRange.low (le (int $portRange.low) 1024) -}} {{/* If a container wants to bind a port <= 1024 change the unprivileged_port_start */}}
-    {{- $_ := set $secContext "sysctls" (mustAppend $secContext.sysctls (dict "name" "net.ipv4.ip_unprivileged_port_start" "value" (printf "%v" $portRange.low))) -}}
+  {{/* If a container wants to bind a port <= 1024 change the unprivileged_port_start */}}
+  {{- if and $portRange.low (le (int $portRange.low) 1024) -}}
+    {{/* That sysctl is not supported when hostNet is enabled */}}
+    {{- if ne (include "ix.v1.common.lib.pod.hostNetwork" (dict "rootCtx" $rootCtx "objectData" $objectData)) "true" -}}
+      {{- $_ := set $secContext "sysctls" (mustAppend $secContext.sysctls (dict "name" "net.ipv4.ip_unprivileged_port_start" "value" (printf "%v" $portRange.low))) -}}
+    {{- end -}}
   {{- end -}}
 
   {{- if or (kindIs "invalid" $secContext.fsGroup) (eq (toString $secContext.fsGroup) "") -}}

--- a/library/common/templates/lib/pod/_podSecurityContext.tpl
+++ b/library/common/templates/lib/pod/_podSecurityContext.tpl
@@ -69,7 +69,7 @@ objectData: The object data to be used to render the Pod.
   {{/* If a container wants to bind a port <= 1024 change the unprivileged_port_start */}}
   {{- if and $portRange.low (le (int $portRange.low) 1024) -}}
     {{/* That sysctl is not supported when hostNet is enabled */}}
-    {{- if ne (include "ix.v1.common.lib.pod.hostNetwork" (dict "rootCtx" $rootCtx "objectData" $objectData)) "true" -}}
+    {{- if ne (include "tc.v1.common.lib.pod.hostNetwork" (dict "rootCtx" $rootCtx "objectData" $objectData)) "true" -}}
       {{- $_ := set $secContext "sysctls" (mustAppend $secContext.sysctls (dict "name" "net.ipv4.ip_unprivileged_port_start" "value" (printf "%v" $portRange.low))) -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

If `net.ipv4.ip_unprivileged_port_start` is set and hostNet is enabled k8s throw an error that is not supported combination

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
