### PR TITLE
fix(common): reenable manifest manager and add deletion logic

### DIFF
--- a/library/common-test/ci/register-operator-values.yaml
+++ b/library/common-test/ci/register-operator-values.yaml
@@ -42,3 +42,10 @@ args:
 
 operator:
   register: true
+
+manifestManager:
+  enabled: false
+  staging: false
+  install: false
+  check: false
+  delete: false

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.10.2
+version: 12.10.3

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -312,8 +312,11 @@ APPURL: ""
 
 # -- Used to inject our own operator manifests into SCALE
 manifestManager:
-  enabled: false
+  enabled: true
   staging: false
+  install: true
+  check: true
+  delete: false
 
 gluetunImage:
   repository: tccr.io/truecharts/gluetun


### PR DESCRIPTION
**Description**
This PR reenables manifest manager by default and creates additional toggles for both install and checks.

It also, more importantly, adds an option to delete resources created using manifestmanager, a prerequisite for moving to building our own operator helm-charts

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
