### PR TITLE
fix(common): default to tcp startup probe for multi-stage probes

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.10.13
+version: 12.10.14

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -165,7 +165,7 @@ workload:
               port: "{{ $.Values.service.main.ports.main.targetPort | default .Values.service.main.ports.main.port }}"
             startup:
               enabled: true
-              type: "{{ .Values.service.main.ports.main.protocol }}"
+              type: "tcp"
               port: "{{ $.Values.service.main.ports.main.targetPort | default .Values.service.main.ports.main.port }}"
 
 # -- Timezone used everywhere applicable


### PR DESCRIPTION
**Description**
This splits the default probe design to define the default container as "running" when it responds on it's port and "ready to accept connections" when it actually has a valid http code on said port.

it's a design frequently employed by some other big helm chart creators and put the seperate startup-probe to good use.
It also allows us to check if it's a http or port/application issue when running charts through tests. As those would fail on different probes.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
