### PR TITLE
feat(common): allow for non-expanded service names

### DIFF
--- a/library/common/templates/spawner/_service.tpl
+++ b/library/common/templates/spawner/_service.tpl
@@ -15,9 +15,13 @@
       {{/* Create a copy of the configmap */}}
       {{- $objectData := (mustDeepCopy $service) -}}
 
-      {{- $objectName := include "tc.v1.common.lib.chart.names.fullname" $ -}}
+      {{- $objectName = (printf "%s-%s" (include "tc.v1.common.lib.chart.names.fullname" $) $name) -}}
       {{- if not $objectData.primary -}}
-        {{- $objectName = (printf "%s-%s" (include "tc.v1.common.lib.chart.names.fullname" $) $name) -}}
+        {{- if hasKey $objectData "expandObjectName" -}}
+          {{- if not $objectData.expandObjectName -}}
+            {{- $objectName = $name -}}
+          {{- end -}}
+        {{- end -}}
       {{- end -}}
 
       {{/* Perform validations */}}


### PR DESCRIPTION
**Description**
Primarily operators sometimes have hardcoded svc names that do not allow for appending the full-name

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
