### PR TITLE
fix(devices): set the hostPathType when a hostPath matches some criteria

### DIFF
--- a/library/common-test/tests/pod/volume_device_test.yaml
+++ b/library/common-test/tests/pod/volume_device_test.yaml
@@ -56,6 +56,69 @@ tests:
               path: /dev/something
               type: BlockDevice
 
+  - it: should pass with specific devices volume
+    set:
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        tty-vol:
+          enabled: true
+          type: device
+          hostPath: /dev/ttyUSB0
+        sda-vol:
+          enabled: true
+          type: device
+          hostPath: /dev/sda
+        hda-vol:
+          enabled: true
+          type: device
+          hostPath: /dev/hda
+        nvme-vol:
+          enabled: true
+          type: device
+          hostPath: /dev/nvme0n1
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tty-vol
+            hostPath:
+              path: /dev/ttyUSB0
+              type: CharDevice
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sda-vol
+            hostPath:
+              path: /dev/sda
+              type: BlockDevice
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: hda-vol
+            hostPath:
+              path: /dev/hda
+              type: BlockDevice
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nvme-vol
+            hostPath:
+              path: /dev/nvme0n1
+              type: BlockDevice
+
+
 # Failures
   - it: should fail without hostPath
     set:

--- a/library/common-test/tests/pod/volume_device_test.yaml
+++ b/library/common-test/tests/pod/volume_device_test.yaml
@@ -118,7 +118,6 @@ tests:
               path: /dev/nvme0n1
               type: BlockDevice
 
-
 # Failures
   - it: should fail without hostPath
     set:

--- a/library/common/templates/lib/pod/volumes/_device.tpl
+++ b/library/common/templates/lib/pod/volumes/_device.tpl
@@ -23,15 +23,16 @@ objectData: The object data to be used to render the volume.
   {{- end -}}
 
   {{- $charDevices := (list "tty")-}}
-  {{- $blockDevices := (list "sd" "hd") -}}
   {{- if not $hostPathType -}}
-
     {{- range $char := $charDevices -}}
       {{- if startsWith (printf "/dev/%v" $char) $hostPath -}}
         {{- $hostPathType = "CharDevice" -}}
       {{- end -}}
     {{- end -}}
+  {{- end -}}
 
+  {{- $blockDevices := (list "sd" "hd" "nvme") -}}
+  {{- if not $hostPathType -}}
     {{- range $block := $blockDevices -}}
       {{- if startsWith (printf "/dev/%v" $block) $hostPath -}}
         {{- $hostPathType = "BlockDevice" -}}

--- a/library/common/templates/lib/pod/volumes/_device.tpl
+++ b/library/common/templates/lib/pod/volumes/_device.tpl
@@ -22,7 +22,7 @@ objectData: The object data to be used to render the volume.
     {{- fail "Persistence - Expected <hostPath> to start with a forward slash [/] on <device> type" -}}
   {{- end -}}
 
-  {{- $charDevices := (list "tty")-}}
+  {{- $charDevices := (list "tty") -}}
   {{- if not $hostPathType -}}
     {{- range $char := $charDevices -}}
       {{- if startsWith (printf "/dev/%v" $char) $hostPath -}}

--- a/library/common/templates/lib/pod/volumes/_device.tpl
+++ b/library/common/templates/lib/pod/volumes/_device.tpl
@@ -22,6 +22,23 @@ objectData: The object data to be used to render the volume.
     {{- fail "Persistence - Expected <hostPath> to start with a forward slash [/] on <device> type" -}}
   {{- end -}}
 
+  {{- $charDevices := (list "tty")-}}
+  {{- $blockDevices := (list "sd" "hd") -}}
+  {{- if not $hostPathType -}}
+
+    {{- range $char := $charDevices -}}
+      {{- if startsWith (printf "/dev/%v" $char) $hostPath -}}
+        {{- $hostPathType = "CharDevice" -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- range $block := $blockDevices -}}
+      {{- if startsWith (printf "/dev/%v" $block) $hostPath -}}
+        {{- $hostPathType = "BlockDevice" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- $types := (list "DirectoryOrCreate" "Directory" "FileOrCreate" "File" "Socket" "CharDevice" "BlockDevice") -}}
   {{- if and $hostPathType (not (mustHas $hostPathType $types)) -}}
     {{- fail (printf "Persistence - Expected <hostPathType> to be one of [%s], but got [%s]" (join ", " $types) $hostPathType) -}}

--- a/library/common/templates/lib/pod/volumes/_device.tpl
+++ b/library/common/templates/lib/pod/volumes/_device.tpl
@@ -25,7 +25,7 @@ objectData: The object data to be used to render the volume.
   {{- $charDevices := (list "tty") -}}
   {{- if not $hostPathType -}}
     {{- range $char := $charDevices -}}
-      {{- if startsWith (printf "/dev/%v" $char) $hostPath -}}
+      {{- if hasPrefix (printf "/dev/%v" $char) $hostPath -}}
         {{- $hostPathType = "CharDevice" -}}
       {{- end -}}
     {{- end -}}
@@ -34,7 +34,7 @@ objectData: The object data to be used to render the volume.
   {{- $blockDevices := (list "sd" "hd" "nvme") -}}
   {{- if not $hostPathType -}}
     {{- range $block := $blockDevices -}}
-      {{- if startsWith (printf "/dev/%v" $block) $hostPath -}}
+      {{- if hasPrefix (printf "/dev/%v" $block) $hostPath -}}
         {{- $hostPathType = "BlockDevice" -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

When someone tries to mount a device from host that does not exist, k8s will create a *directory* (on the host) in it's place
That means that when they actually plug the usb it will still be a directory unless manually fixed.

So when we detect one of those devices, lets set its hostPathType to avoid that.
![image](https://github.com/truecharts/library-charts/assets/47820033/4b3e7ce8-5412-4b5e-a5d6-2305d59a0685)


We can extend the "filter" list once we figure out more things

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
