### PR TITLE
fix(cnpg): disable metrics by default

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 12.14.7
+version: 12.14.8

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -64,8 +64,15 @@ spec:
         requests:
           storage: {{ tpl ($values.storage.walsize | default $.Values.fallbackDefaults.vctSize) $ | quote }}
 
+  {{- $monitoring := true -}}
+  {{- with $values.monitoring -}}
+    {{- if not (kindIs "invalid" .enablePodMonitor) -}}
+      {{- $monitoring = .enablePodMonitor -}}
+    {{- end -}}
+  {{- end }}
+
   monitoring:
-    enablePodMonitor: {{ $values.monitoring.enablePodMonitor | default false }}
+    enablePodMonitor: {{ $monitoring }}
 
   nodeMaintenanceWindow:
     inProgress: false

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -65,7 +65,7 @@ spec:
           storage: {{ tpl ($values.storage.walsize | default $.Values.fallbackDefaults.vctSize) $ | quote }}
 
   monitoring:
-    enablePodMonitor: {{ $values.monitoring.enablePodMonitor | default true }}
+    enablePodMonitor: {{ $values.monitoring.enablePodMonitor | default false }}
 
   nodeMaintenanceWindow:
     inProgress: false


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Disables PodMonitor by default, because otherwise it makes prometheus operator a hard dependency.
Besides that, as it was currently, you could not disable it per chart. Because `false | default true` is always true.

Other things considered: 

Fix the logic, but keep default enabled, introduce a flag in the UI to apps with CNPG that can disable metrics


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
