### PR TITLE
chore(tests): explicitly set a release-name everywhere

### DIFF
--- a/library/common-test/tests/addons/autoperms_test.yaml
+++ b/library/common-test/tests/addons/autoperms_test.yaml
@@ -1,6 +1,8 @@
 suite: auto perms test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should render permissions job
     set:

--- a/library/common-test/tests/addons/codeserver_test.yaml
+++ b/library/common-test/tests/addons/codeserver_test.yaml
@@ -1,6 +1,8 @@
 suite: addon codeserver
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: addon enabled should pass
     set:
@@ -41,23 +43,23 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test-codeserver
+          value: test-release-name-common-test-codeserver
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *ServiceDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *AddonServiceDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-codeserver
+          value: test-release-name-common-test-codeserver
 
   - it: addon enabled should pass without other service
     set:
@@ -82,19 +84,19 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test-codeserver
+          value: test-release-name-common-test-codeserver
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *AddonServiceDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
 
   - it: addon enabled should pass and mount volume with targetSelector on other container only
     set:
@@ -128,15 +130,15 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test-codeserver
+          value: test-release-name-common-test-codeserver
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/library/common-test/tests/addons/netshoot_test.yaml
+++ b/library/common-test/tests/addons/netshoot_test.yaml
@@ -1,6 +1,8 @@
 suite: addon netshoot
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: addon enabled should pass
     set:
@@ -38,16 +40,16 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-netshoot
+          value: test-release-name-common-test-netshoot
       - documentIndex: *ServiceDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test

--- a/library/common-test/tests/addons/vpn_test.yaml
+++ b/library/common-test/tests/addons/vpn_test.yaml
@@ -1,6 +1,8 @@
 suite: addon vpn
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: addon vpn gluetun enabled with config and env should pass
     set:
@@ -52,7 +54,7 @@ tests:
       - documentIndex: *SecretDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-vpnconfig
+          value: test-release-name-common-test-vpnconfig
       - documentIndex: *SecretDocument
         equal:
           path: stringData
@@ -63,19 +65,19 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *ServiceDocument
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         notContains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -132,7 +134,7 @@ tests:
           content:
             name: vpnconfig
             secret:
-              secretName: release-name-common-test-vpnconfig
+              secretName: test-release-name-common-test-vpnconfig
               defaultMode: 0777
               optional: false
               items:
@@ -182,11 +184,11 @@ tests:
       - documentIndex: *SecretDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-vpnconfig
+          value: test-release-name-common-test-vpnconfig
       - documentIndex: *ConfigMapDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-vpnscripts
+          value: test-release-name-common-test-vpnscripts
       - documentIndex: *ConfigMapDocument
         equal:
           path: data
@@ -207,7 +209,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -239,14 +241,14 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes
           content:
             name: vpnconfig
             secret:
-              secretName: release-name-common-test-vpnconfig
+              secretName: test-release-name-common-test-vpnconfig
               defaultMode: 0777
               optional: false
               items:
@@ -295,7 +297,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -313,7 +315,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes
@@ -358,7 +360,7 @@ tests:
       - documentIndex: *JobDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-autopermissions
+          value: test-release-name-common-test-autopermissions
       - documentIndex: *JobDocument
         contains:
           path: spec.template.spec.volumes
@@ -394,7 +396,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -412,7 +414,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes
@@ -447,7 +449,7 @@ tests:
       - documentIndex: *JobDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-autopermissions
+          value: test-release-name-common-test-autopermissions
       - documentIndex: *JobDocument
         contains:
           path: spec.template.spec.volumes
@@ -488,7 +490,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -506,7 +508,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes
@@ -540,11 +542,11 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-tailscale
+          value: test-release-name-common-test-tailscale
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].env
@@ -651,11 +653,11 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-tailscale
+          value: test-release-name-common-test-tailscale
       - documentIndex: *DeploymentDocument
         isSubset:
           path: spec.template.spec.containers[1].securityContext
@@ -697,7 +699,7 @@ tests:
       - documentIndex: *JobDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-autopermissions
+          value: test-release-name-common-test-autopermissions
       - documentIndex: *JobDocument
         contains:
           path: spec.template.spec.volumes
@@ -733,7 +735,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -751,7 +753,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes
@@ -792,7 +794,7 @@ tests:
       - documentIndex: *JobDocument
         equal:
           path: metadata.name
-          value: release-name-common-test-autopermissions
+          value: test-release-name-common-test-autopermissions
       - documentIndex: *JobDocument
         contains:
           path: spec.template.spec.volumes
@@ -828,7 +830,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[0].name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].volumeMounts
@@ -846,7 +848,7 @@ tests:
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
-          value: release-name-common-test-vpn
+          value: test-release-name-common-test-vpn
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.volumes

--- a/library/common-test/tests/certificate/data_test.yaml
+++ b/library/common-test/tests/certificate/data_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with secret created for certificate
     set:

--- a/library/common-test/tests/certificate/metadata_test.yaml
+++ b/library/common-test/tests/certificate/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with certificate created with labels and annotations
     set:
@@ -48,11 +50,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/certificate/name_test.yaml
+++ b/library/common-test/tests/certificate/name_test.yaml
@@ -1,6 +1,8 @@
 suite: certificate name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -28,7 +30,7 @@ tests:
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-cert1
+          value: test-release-name-common-test-my-cert1
       - documentIndex: &otherSecretDoc 1
         isKind:
           of: Secret
@@ -38,4 +40,4 @@ tests:
       - documentIndex: *otherSecretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-cert2
+          value: test-release-name-common-test-my-cert2

--- a/library/common-test/tests/certificate/validation_test.yaml
+++ b/library/common-test/tests/certificate/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: certificate validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -10,7 +12,7 @@ tests:
           id: 1
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-certificate-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-certificate-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -20,7 +22,7 @@ tests:
           id: 1
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-cert] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-cert] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/cnpg/custom_conf_test.yaml
+++ b/library/common-test/tests/cnpg/custom_conf_test.yaml
@@ -1,6 +1,8 @@
 suite: cnpg custom conf test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with custom-conf
     set:

--- a/library/common-test/tests/cnpg/stop_test.yaml
+++ b/library/common-test/tests/cnpg/stop_test.yaml
@@ -1,6 +1,8 @@
 suite: cnpg stop test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with hibernate
     set:

--- a/library/common-test/tests/configmap/data_test.yaml
+++ b/library/common-test/tests/configmap/data_test.yaml
@@ -1,6 +1,8 @@
 suite: configmap data test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with key-value data
     set:

--- a/library/common-test/tests/configmap/metadata_test.yaml
+++ b/library/common-test/tests/configmap/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with configmap created with labels and annotations
     set:
@@ -45,11 +47,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/configmap/name_test.yaml
+++ b/library/common-test/tests/configmap/name_test.yaml
@@ -1,6 +1,8 @@
 suite: configmap name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -23,7 +25,7 @@ tests:
       - documentIndex: *configmapDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-configmap1
+          value: test-release-name-common-test-my-configmap1
       - documentIndex: &otherConfigmapDoc 1
         isKind:
           of: ConfigMap
@@ -33,4 +35,4 @@ tests:
       - documentIndex: *otherConfigmapDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-configmap2
+          value: test-release-name-common-test-my-configmap2

--- a/library/common-test/tests/configmap/validation_test.yaml
+++ b/library/common-test/tests/configmap/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: configmap validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -11,7 +13,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-configmap-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-configmap-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -22,7 +24,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-configmap] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-configmap] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/container/arg_test.yaml
+++ b/library/common-test/tests/container/arg_test.yaml
@@ -1,6 +1,8 @@
 suite: container arg test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct multiple args
     set:

--- a/library/common-test/tests/container/command_test.yaml
+++ b/library/common-test/tests/container/command_test.yaml
@@ -1,6 +1,8 @@
 suite: container command test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct command in scalar
     set:

--- a/library/common-test/tests/container/envFixed_test .yaml
+++ b/library/common-test/tests/container/envFixed_test .yaml
@@ -1,6 +1,8 @@
 suite: container envFixed test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct fixed envs
     set:

--- a/library/common-test/tests/container/envFrom_test.yaml
+++ b/library/common-test/tests/container/envFrom_test.yaml
@@ -1,6 +1,8 @@
 suite: container envFrom test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct envFrom
     set:
@@ -56,9 +58,9 @@ tests:
           content:
             envFrom:
               - configMapRef:
-                  name: release-name-common-test-configmap-name
+                  name: test-release-name-common-test-configmap-name
               - secretRef:
-                  name: release-name-common-test-secret-name
+                  name: test-release-name-common-test-secret-name
 
   - it: should create the correct envFrom without expanding the name
     set:

--- a/library/common-test/tests/container/envList_test.yaml
+++ b/library/common-test/tests/container/envList_test.yaml
@@ -1,6 +1,8 @@
 suite: container envList test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct envList
     set:

--- a/library/common-test/tests/container/env_dupe_test.yaml
+++ b/library/common-test/tests/container/env_dupe_test.yaml
@@ -1,6 +1,8 @@
 suite: container env dupe test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
 # Failures
   - it: should fail with dupe env in env and envList

--- a/library/common-test/tests/container/env_test.yaml
+++ b/library/common-test/tests/container/env_test.yaml
@@ -1,6 +1,8 @@
 suite: container env test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct env
     set:
@@ -93,7 +95,7 @@ tests:
             valueFrom:
               configMapKeyRef:
                 key: key1
-                name: release-name-common-test-configmap-name
+                name: test-release-name-common-test-configmap-name
       - documentIndex: *deploymentDoc
         contains:
           path: spec.template.spec.containers[0].env
@@ -102,7 +104,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 key: key2
-                name: release-name-common-test-secret-name
+                name: test-release-name-common-test-secret-name
       - documentIndex: *deploymentDoc
         contains:
           path: spec.template.spec.containers[0].env

--- a/library/common-test/tests/container/image_test.yaml
+++ b/library/common-test/tests/container/image_test.yaml
@@ -1,6 +1,8 @@
 suite: container image test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct image
     set:

--- a/library/common-test/tests/container/lifecycle_test.yaml
+++ b/library/common-test/tests/container/lifecycle_test.yaml
@@ -1,6 +1,8 @@
 suite: container lifecycle test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with lifecycle
     set:

--- a/library/common-test/tests/container/name_test.yaml
+++ b/library/common-test/tests/container/name_test.yaml
@@ -1,6 +1,8 @@
 suite: container name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct container name
     set:
@@ -42,9 +44,9 @@ tests:
         isSubset:
           path: spec.template.spec.containers[0]
           content:
-            name: release-name-common-test
+            name: test-release-name-common-test
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.containers[1]
           content:
-            name: release-name-common-test-container-name2
+            name: test-release-name-common-test-container-name2

--- a/library/common-test/tests/container/ports_test.yaml
+++ b/library/common-test/tests/container/ports_test.yaml
@@ -1,6 +1,8 @@
 suite: container ports test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the correct ports without selector
     set:

--- a/library/common-test/tests/container/probes_test.yaml
+++ b/library/common-test/tests/container/probes_test.yaml
@@ -1,6 +1,8 @@
 suite: container probe test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the probes correctly
     set:

--- a/library/common-test/tests/container/resources_test.yaml
+++ b/library/common-test/tests/container/resources_test.yaml
@@ -1,6 +1,8 @@
 suite: container resources test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the resources correctly
     set:

--- a/library/common-test/tests/container/securityContext_test.yaml
+++ b/library/common-test/tests/container/securityContext_test.yaml
@@ -1,6 +1,8 @@
 suite: container security context test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create the securityContext correctly
     set:

--- a/library/common-test/tests/container/termination_test.yaml
+++ b/library/common-test/tests/container/termination_test.yaml
@@ -1,6 +1,8 @@
 suite: container termination test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with termination set
     set:

--- a/library/common-test/tests/container/tty_stdin_test.yaml
+++ b/library/common-test/tests/container/tty_stdin_test.yaml
@@ -1,6 +1,8 @@
 suite: container tty and stdin test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass without tty and stdin
     set:

--- a/library/common-test/tests/container/validation_test.yaml
+++ b/library/common-test/tests/container/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: container validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with more than one primary container on a workload
     set:

--- a/library/common-test/tests/container/volumeMounts_test.yaml
+++ b/library/common-test/tests/container/volumeMounts_test.yaml
@@ -1,6 +1,8 @@
 suite: container volumeMounts test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with shared volume on multiple workloads and containers with targetSelectAll
     set:

--- a/library/common-test/tests/cronjob/metadata_test.yaml
+++ b/library/common-test/tests/cronjob/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with cronjob created with labels and annotations
     set:
@@ -53,11 +55,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -70,8 +72,8 @@ tests:
           value:
             pod.name: workload-name
             app: common-test-1.0.0
-            release: RELEASE-NAME
-            app.kubernetes.io/instance: RELEASE-NAME
+            release: test-release-name
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: v9.9.9

--- a/library/common-test/tests/cronjob/spec_test.yaml
+++ b/library/common-test/tests/cronjob/spec_test.yaml
@@ -1,6 +1,8 @@
 suite: cronjob spec test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with workload enabled
     set:

--- a/library/common-test/tests/cronjob/validation_test.yaml
+++ b/library/common-test/tests/cronjob/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: cronjob validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with invalid concurrencyPolicy
     set:

--- a/library/common-test/tests/daemonset/metadata_test.yaml
+++ b/library/common-test/tests/daemonset/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with daemonset created with labels and annotations
     set:
@@ -52,11 +54,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -69,15 +71,15 @@ tests:
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *daemonSetDoc
         equal:
           path: spec.template.metadata.labels
           value:
             pod.name: workload-name
             app: common-test-1.0.0
-            release: RELEASE-NAME
-            app.kubernetes.io/instance: RELEASE-NAME
+            release: test-release-name
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: v9.9.9
@@ -112,20 +114,20 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-other-workload-name
+          value: test-release-name-common-test-other-workload-name
       - documentIndex: *daemonSetDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: other-workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *daemonSetDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: other-workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test
       - documentIndex: &otherDaemonSetDoc 1
         isKind:
@@ -133,18 +135,18 @@ tests:
       - documentIndex: *otherDaemonSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *otherDaemonSetDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *otherDaemonSetDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test

--- a/library/common-test/tests/daemonset/spec_test.yaml
+++ b/library/common-test/tests/daemonset/spec_test.yaml
@@ -1,6 +1,8 @@
 suite: daemonset spec test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with workload enabled
     set:

--- a/library/common-test/tests/daemonset/validation_test.yaml
+++ b/library/common-test/tests/daemonset/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: daemonset validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with invalid strategy
     set:

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with defaults
     set:
@@ -72,11 +74,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
       - documentIndex: *deploymentDoc

--- a/library/common-test/tests/deployment/metadata_test.yaml
+++ b/library/common-test/tests/deployment/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with deployment created with labels and annotations
     set:
@@ -52,11 +54,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -69,15 +71,15 @@ tests:
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *deploymentDoc
         equal:
           path: spec.template.metadata.labels
           value:
             pod.name: workload-name
             app: common-test-1.0.0
-            release: RELEASE-NAME
-            app.kubernetes.io/instance: RELEASE-NAME
+            release: test-release-name
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: v9.9.9
@@ -112,20 +114,20 @@ tests:
       - documentIndex: *deploymentDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-other-workload-name
+          value: test-release-name-common-test-other-workload-name
       - documentIndex: *deploymentDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: other-workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: other-workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test
       - documentIndex: &otherDeploymentDoc 1
         isKind:
@@ -133,18 +135,18 @@ tests:
       - documentIndex: *otherDeploymentDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *otherDeploymentDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *otherDeploymentDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test

--- a/library/common-test/tests/deployment/spec_test.yaml
+++ b/library/common-test/tests/deployment/spec_test.yaml
@@ -1,6 +1,8 @@
 suite: deployment spec test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with workload enabled
     set:

--- a/library/common-test/tests/deployment/validation_test.yaml
+++ b/library/common-test/tests/deployment/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: deployment validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with invalid strategy
     set:

--- a/library/common-test/tests/externalInterface/metadata_test.yaml
+++ b/library/common-test/tests/externalInterface/metadata_test.yaml
@@ -2,17 +2,17 @@ suite: externalInterface metadata test
 templates:
   - common.yaml
 release:
-  name: release-name
+  name: test-release-name
 tests:
   - it: should generate correct annotations without selector
     set:
       # Simulate middleware injection
       ixExternalInterfacesConfiguration:
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
       ixExternalInterfacesConfigurationNames:
-        - ix-release-name-0
-        - ix-release-name-1
+        - ix-test-release-name-0
+        - ix-test-release-name-1
       scaleExternalInterface:
         - hostInterface: enp0s3
           ipam:
@@ -63,12 +63,12 @@ tests:
       - documentIndex: *deploymentDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0, ix-release-name-1
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0, ix-test-release-name-1
       - documentIndex: &statefulSetDoc 3
         isKind:
           of: StatefulSet
@@ -78,22 +78,22 @@ tests:
       - documentIndex: *statefulSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-workload-name2
+          value: test-release-name-common-test-workload-name2
       - documentIndex: *statefulSetDoc
         isNotSubset:
           path: spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0, ix-release-name-1
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0, ix-test-release-name-1
 
   - it: should generate correct annotations with targetSelectAll
     set:
       # Simulate middleware injection
       ixExternalInterfacesConfiguration:
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
       ixExternalInterfacesConfigurationNames:
-        - ix-release-name-0
-        - ix-release-name-1
+        - ix-test-release-name-0
+        - ix-test-release-name-1
       scaleExternalInterface:
         - hostInterface: enp0s3
           ipam:
@@ -137,12 +137,12 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *daemonSetDoc
         isSubset:
           path: spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0, ix-release-name-1
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0, ix-test-release-name-1
       - documentIndex: &jobDoc 3
         isKind:
           of: Job
@@ -152,22 +152,22 @@ tests:
       - documentIndex: *jobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-workload-name2
+          value: test-release-name-common-test-workload-name2
       - documentIndex: *jobDoc
         isSubset:
           path: spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0, ix-release-name-1
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0, ix-test-release-name-1
 
   - it: should generate correct annotations with targetSelector
     set:
       # Simulate middleware injection
       ixExternalInterfacesConfiguration:
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
       ixExternalInterfacesConfigurationNames:
-        - ix-release-name-0
-        - ix-release-name-1
+        - ix-test-release-name-0
+        - ix-test-release-name-1
       scaleExternalInterface:
         - hostInterface: enp0s3
           ipam:
@@ -215,12 +215,12 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *daemonSetDoc
         isSubset:
           path: spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0, ix-release-name-1
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0, ix-test-release-name-1
       - documentIndex: &cronJobDoc 3
         isKind:
           of: CronJob
@@ -230,9 +230,9 @@ tests:
       - documentIndex: *cronJobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-workload-name2
+          value: test-release-name-common-test-workload-name2
       - documentIndex: *cronJobDoc
         isSubset:
           path: spec.jobTemplate.spec.template.metadata.annotations
           content:
-            k8s.v1.cni.cncf.io/networks: ix-release-name-0
+            k8s.v1.cni.cncf.io/networks: ix-test-release-name-0

--- a/library/common-test/tests/externalInterface/name_test.yaml
+++ b/library/common-test/tests/externalInterface/name_test.yaml
@@ -2,17 +2,17 @@ suite: externalInterface name test
 templates:
   - common.yaml
 release:
-  name: release-name
+  name: test-release-name
 tests:
   - it: should generate correct name NetworkAttachmentDefinition
     set:
       # Simulate middleware injection
       ixExternalInterfacesConfiguration:
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens4s0", "ipam": {"type": "dhcp"}}'
       ixExternalInterfacesConfigurationNames:
-        - ix-release-name-0
-        - ix-release-name-1
+        - ix-test-release-name-0
+        - ix-test-release-name-1
       scaleExternalInterface:
         - hostInterface: enp0s3
           ipam:
@@ -30,7 +30,7 @@ tests:
       - documentIndex: *networkDoc
         equal:
           path: metadata.name
-          value: ix-release-name-0
+          value: ix-test-release-name-0
       - documentIndex: &otherNetworkDoc 1
         isKind:
           of: NetworkAttachmentDefinition
@@ -40,4 +40,4 @@ tests:
       - documentIndex: *otherNetworkDoc
         equal:
           path: metadata.name
-          value: ix-release-name-1
+          value: ix-test-release-name-1

--- a/library/common-test/tests/externalInterface/validation_test.yaml
+++ b/library/common-test/tests/externalInterface/validation_test.yaml
@@ -2,7 +2,7 @@ suite: external interface validation test
 templates:
   - common.yaml
 release:
-  name: release-name
+  name: test-release-name
 tests:
   - it: should fail with targetSelector not a list
     set:
@@ -119,7 +119,7 @@ tests:
     set:
       # Simulate middleware injection
       ixExternalInterfacesConfiguration:
-        - '{"cniVersion": "0.3.1", "name": "ix-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
+        - '{"cniVersion": "0.3.1", "name": "ix-test-release-name-0", "type": "macvlan", "master": "ens3s0", "ipam": {"type": "dhcp"}}'
       ixExternalInterfaceConfigurationNames: []
       scaleExternalInterface:
         - hostInterface: enp0s3

--- a/library/common-test/tests/extraTpl/extratpl_test.yaml
+++ b/library/common-test/tests/extraTpl/extratpl_test.yaml
@@ -1,6 +1,8 @@
 suite: extra tpl test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with extra tpl
     set:
@@ -10,7 +12,7 @@ tests:
           apiVersion: v1
           kind: Service
           metadata:
-            name: release-name-common-test
+            name: test-release-name-common-test
           spec:
             type: ClusterIP
             publishNotReadyAddresses: false
@@ -23,14 +25,14 @@ tests:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: release-name-common-test
+            name: test-release-name-common-test
             labels:
               some-label: {{ .Values.someKey }}
           spec:
             template:
               spec:
                 containers:
-                  - name: release-name-common-test
+                  - name: test-release-name-common-test
         - "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: {{ .Values.someKey }}"
     asserts:
       - documentIndex: &serviceDoc 0

--- a/library/common-test/tests/imagePullSecret/data_test.yaml
+++ b/library/common-test/tests/imagePullSecret/data_test.yaml
@@ -1,6 +1,8 @@
 suite: imagePullSecret data test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with data
     set:

--- a/library/common-test/tests/imagePullSecret/metadata_test.yaml
+++ b/library/common-test/tests/imagePullSecret/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with secret created with labels and annotations
     set:
@@ -48,11 +50,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/imagePullSecret/name_test.yaml
+++ b/library/common-test/tests/imagePullSecret/name_test.yaml
@@ -1,6 +1,8 @@
 suite: imagePullSecret name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -29,7 +31,7 @@ tests:
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-pull-secret1
+          value: test-release-name-common-test-my-pull-secret1
       - documentIndex: &otherSecretDoc 1
         isKind:
           of: Secret
@@ -39,4 +41,4 @@ tests:
       - documentIndex: *otherSecretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-pull-secret2
+          value: test-release-name-common-test-my-pull-secret2

--- a/library/common-test/tests/imagePullSecret/validation_test.yaml
+++ b/library/common-test/tests/imagePullSecret/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: imagePullSecret validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -14,7 +16,7 @@ tests:
             email: mail
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-pull-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-pull-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -24,7 +26,7 @@ tests:
           data: *data
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-pull-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-pull-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/ingress/metadata_test.yaml
+++ b/library/common-test/tests/ingress/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: default metadata should pass
     set:
@@ -37,11 +39,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
 
@@ -84,11 +86,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             test_label: test

--- a/library/common-test/tests/ingress/presence_test.yaml
+++ b/library/common-test/tests/ingress/presence_test.yaml
@@ -1,6 +1,8 @@
 suite: ingress presence
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: default should pass
     asserts:

--- a/library/common-test/tests/ingress/service_reference_test.yaml
+++ b/library/common-test/tests/ingress/service_reference_test.yaml
@@ -1,6 +1,8 @@
 suite: ingress service reference
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: default should pass
     set:
@@ -27,7 +29,7 @@ tests:
         equal:
           path: spec.rules[0].http.paths[0].backend.service
           value:
-            name: release-name-common-test
+            name: test-release-name-common-test
             port:
               number: 12345
 

--- a/library/common-test/tests/ingress/tls_test.yaml
+++ b/library/common-test/tests/ingress/tls_test.yaml
@@ -1,6 +1,8 @@
 suite: ingress tls
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: default should pass
     set:
@@ -123,6 +125,6 @@ tests:
         equal:
           path: spec.tls[0]
           value:
-            secretName: RELEASE-NAME-secret
+            secretName: test-release-name-secret
             hosts:
               - hostname

--- a/library/common-test/tests/ingress/values_test.yaml
+++ b/library/common-test/tests/ingress/values_test.yaml
@@ -1,6 +1,8 @@
 suite: ingress values
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: default should pass
     set:
@@ -94,7 +96,7 @@ tests:
       - documentIndex: *ingressDocument
         equal:
           path: spec.rules[0].host
-          value: RELEASE-NAME.hostname
+          value: test-release-name.hostname
 
   - it: path with template should pass
     set:
@@ -125,4 +127,4 @@ tests:
       - documentIndex: *ingressDocument
         equal:
           path: spec.rules[0].http.paths[0].path
-          value: "/RELEASE-NAME.path"
+          value: "/test-release-name.path"

--- a/library/common-test/tests/initContainer/data_test.yaml
+++ b/library/common-test/tests/initContainer/data_test.yaml
@@ -1,6 +1,8 @@
 suite: init container data test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct init container
     set:
@@ -84,7 +86,7 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[0]
           content:
-            name: release-name-common-test-install-container-name2
+            name: test-release-name-common-test-install-container-name2
             image: bash:latest
             command:
               - /bin/sh
@@ -123,7 +125,7 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[1]
           content:
-            name: release-name-common-test-init-container-name1
+            name: test-release-name-common-test-init-container-name1
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.initContainers[1]

--- a/library/common-test/tests/initContainer/data_upgrade_test.yaml
+++ b/library/common-test/tests/initContainer/data_upgrade_test.yaml
@@ -3,6 +3,7 @@ templates:
   - common.yaml
 release:
   upgrade: true
+  name: test-release-name
 tests:
   - it: should generate correct init container
     set:
@@ -86,7 +87,7 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[0]
           content:
-            name: release-name-common-test-upgrade-container-name2
+            name: test-release-name-common-test-upgrade-container-name2
             image: bash:latest
             command:
               - /bin/sh
@@ -125,7 +126,7 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[1]
           content:
-            name: release-name-common-test-init-container-name1
+            name: test-release-name-common-test-init-container-name1
       - documentIndex: *deploymentDoc
         isNull:
           path: spec.template.spec.initContainers[1].command

--- a/library/common-test/tests/initContainer/name_test.yaml
+++ b/library/common-test/tests/initContainer/name_test.yaml
@@ -1,6 +1,8 @@
 suite: init container name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct init container name
     set:
@@ -34,9 +36,9 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[0]
           content:
-            name: release-name-common-test-install-container-name2
+            name: test-release-name-common-test-install-container-name2
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.initContainers[1]
           content:
-            name: release-name-common-test-init-container-name1
+            name: test-release-name-common-test-init-container-name1

--- a/library/common-test/tests/initContainer/name_upgrade_test.yaml
+++ b/library/common-test/tests/initContainer/name_upgrade_test.yaml
@@ -3,6 +3,7 @@ templates:
   - common.yaml
 release:
   upgrade: true
+  name: test-release-name
 tests:
   - it: should generate correct init container name
     set:
@@ -36,9 +37,9 @@ tests:
         isSubset:
           path: spec.template.spec.initContainers[0]
           content:
-            name: release-name-common-test-upgrade-container-name2
+            name: test-release-name-common-test-upgrade-container-name2
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.initContainers[1]
           content:
-            name: release-name-common-test-init-container-name1
+            name: test-release-name-common-test-init-container-name1

--- a/library/common-test/tests/initContainer/validation_test.yaml
+++ b/library/common-test/tests/initContainer/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: init container data test (upgrade)
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
 # Failures
   - it: should fail with empty type on init container

--- a/library/common-test/tests/job/metadata_test.yaml
+++ b/library/common-test/tests/job/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with job created with labels and annotations
     set:
@@ -52,11 +54,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -69,8 +71,8 @@ tests:
           value:
             pod.name: workload-name
             app: common-test-1.0.0
-            release: RELEASE-NAME
-            app.kubernetes.io/instance: RELEASE-NAME
+            release: test-release-name
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: v9.9.9

--- a/library/common-test/tests/job/spec_test.yaml
+++ b/library/common-test/tests/job/spec_test.yaml
@@ -1,6 +1,8 @@
 suite: job spec test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with workload enabled
     set:

--- a/library/common-test/tests/job/validation_test.yaml
+++ b/library/common-test/tests/job/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: job validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with invalid completionMode
     set:

--- a/library/common-test/tests/metrics/defaults_test.yaml
+++ b/library/common-test/tests/metrics/defaults_test.yaml
@@ -1,6 +1,8 @@
 suite: metrics defaults
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: default should pass
     set:

--- a/library/common-test/tests/operator/operator_test.yaml
+++ b/library/common-test/tests/operator/operator_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   version: &version v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with key-value data
     set:
@@ -17,7 +19,7 @@ tests:
       - documentIndex: *configmapDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-tc-data
+          value: test-release-name-common-test-tc-data
       - documentIndex: *configmapDoc
         equal:
           path: data

--- a/library/common-test/tests/persistence/metadata_test.yaml
+++ b/library/common-test/tests/persistence/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with pvc created with labels and annotations
     set:
@@ -47,11 +49,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -80,10 +82,10 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer

--- a/library/common-test/tests/persistence/names_test.yaml
+++ b/library/common-test/tests/persistence/names_test.yaml
@@ -1,6 +1,8 @@
 suite: persistence pvc name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -21,7 +23,7 @@ tests:
       - documentIndex: *pvcDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1
+          value: test-release-name-common-test-my-volume1
       - documentIndex: &otherPvcDoc 1
         isKind:
           of: PersistentVolumeClaim
@@ -31,4 +33,4 @@ tests:
       - documentIndex: *otherPvcDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2
+          value: test-release-name-common-test-my-volume2

--- a/library/common-test/tests/persistence/pvc_data_test.yaml
+++ b/library/common-test/tests/persistence/pvc_data_test.yaml
@@ -1,6 +1,8 @@
 suite: pvc data name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create pvc
     set:
@@ -19,7 +21,7 @@ tests:
       - documentIndex: *pvcDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1
+          value: test-release-name-common-test-my-volume1
       - documentIndex: *pvcDoc
         equal:
           path: spec.accessModes

--- a/library/common-test/tests/persistence/validation_test.yaml
+++ b/library/common-test/tests/persistence/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: persistence validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with annotations not a dict
     set:

--- a/library/common-test/tests/pod/automount_sa_token_test.yaml
+++ b/library/common-test/tests/pod/automount_sa_token_test.yaml
@@ -1,6 +1,8 @@
 suite: pod auto mount sa token test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with automountServiceAccountToken disabled from "global"
     set:

--- a/library/common-test/tests/pod/dns_config_test.yaml
+++ b/library/common-test/tests/pod/dns_config_test.yaml
@@ -1,6 +1,8 @@
 suite: pod dns config test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty dnsConfig
     set:

--- a/library/common-test/tests/pod/dns_policy_test.yaml
+++ b/library/common-test/tests/pod/dns_policy_test.yaml
@@ -1,6 +1,8 @@
 suite: pod dns policy test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty dnsPolicy
     set:

--- a/library/common-test/tests/pod/enable_service_links_test.yaml
+++ b/library/common-test/tests/pod/enable_service_links_test.yaml
@@ -1,6 +1,8 @@
 suite: pod enableServiceLinks test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with enableServiceLinks disabled from "global"
     set:

--- a/library/common-test/tests/pod/host-aliases_test.yaml
+++ b/library/common-test/tests/pod/host-aliases_test.yaml
@@ -1,6 +1,8 @@
 suite: pod hostAliases test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty hostAliases
     set:

--- a/library/common-test/tests/pod/host_network_test.yaml
+++ b/library/common-test/tests/pod/host_network_test.yaml
@@ -1,6 +1,8 @@
 suite: pod hostnetwork test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with hostnetwork disabled from "global"
     set:

--- a/library/common-test/tests/pod/host_pid_test.yaml
+++ b/library/common-test/tests/pod/host_pid_test.yaml
@@ -1,6 +1,8 @@
 suite: pod hostpid test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with hostpid disabled from "global"
     set:

--- a/library/common-test/tests/pod/hostname_test.yaml
+++ b/library/common-test/tests/pod/hostname_test.yaml
@@ -1,6 +1,8 @@
 suite: pod hostname test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty hostname
     set:

--- a/library/common-test/tests/pod/image_pull_secret_test.yaml
+++ b/library/common-test/tests/pod/image_pull_secret_test.yaml
@@ -1,6 +1,8 @@
 suite: pod imagePullSecret test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should assign multiple imagePullSecret to primary pod
     set:
@@ -38,13 +40,13 @@ tests:
       - documentIndex: *cronJobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *cronJobDoc
         equal:
           path: spec.jobTemplate.spec.template.spec.imagePullSecrets
           value:
-            - name: release-name-common-test-pull-secret1
-            - name: release-name-common-test-pull-secret2
+            - name: test-release-name-common-test-pull-secret1
+            - name: test-release-name-common-test-pull-secret2
       - documentIndex: &otherDeploymentDoc 3
         isKind:
           of: Deployment
@@ -90,8 +92,8 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets
           value:
-            - name: release-name-common-test-pull-secret1
-            - name: release-name-common-test-pull-secret2
+            - name: test-release-name-common-test-pull-secret1
+            - name: test-release-name-common-test-pull-secret2
       - documentIndex: &otherDeploymentDoc 3
         isKind:
           of: Deployment
@@ -99,8 +101,8 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets
           value:
-            - name: release-name-common-test-pull-secret1
-            - name: release-name-common-test-pull-secret2
+            - name: test-release-name-common-test-pull-secret1
+            - name: test-release-name-common-test-pull-secret2
 
   - it: should assign imagePullSecret to selected pods
     set:
@@ -143,8 +145,8 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets
           value:
-            - name: release-name-common-test-pull-secret1
-            - name: release-name-common-test-pull-secret2
+            - name: test-release-name-common-test-pull-secret1
+            - name: test-release-name-common-test-pull-secret2
       - documentIndex: &otherDeploymentDoc 3
         isKind:
           of: Deployment
@@ -152,4 +154,4 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets
           value:
-            - name: release-name-common-test-pull-secret1
+            - name: test-release-name-common-test-pull-secret1

--- a/library/common-test/tests/pod/node_selector_test.yaml
+++ b/library/common-test/tests/pod/node_selector_test.yaml
@@ -1,6 +1,8 @@
 suite: pod node selector test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty nodeSelector
     set:

--- a/library/common-test/tests/pod/priority_class_name_test.yaml
+++ b/library/common-test/tests/pod/priority_class_name_test.yaml
@@ -1,6 +1,8 @@
 suite: pod priority class name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty priorityClassName
     set:

--- a/library/common-test/tests/pod/restart_policy_test.yaml
+++ b/library/common-test/tests/pod/restart_policy_test.yaml
@@ -1,6 +1,8 @@
 suite: pod restart policy test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with restartPolicy empty
     set:

--- a/library/common-test/tests/pod/runtime_class_name_test.yaml
+++ b/library/common-test/tests/pod/runtime_class_name_test.yaml
@@ -1,6 +1,8 @@
 suite: pod runtime class name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty runtimeClassName
     set:

--- a/library/common-test/tests/pod/scheduler_name_test.yaml
+++ b/library/common-test/tests/pod/scheduler_name_test.yaml
@@ -1,6 +1,8 @@
 suite: pod scheduler name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty schedulerName
     set:

--- a/library/common-test/tests/pod/securityContext.yaml
+++ b/library/common-test/tests/pod/securityContext.yaml
@@ -1,6 +1,8 @@
 suite: pod securityContext test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with securityContext from "global"
     set:

--- a/library/common-test/tests/pod/service_account_name_test.yaml
+++ b/library/common-test/tests/pod/service_account_name_test.yaml
@@ -1,6 +1,8 @@
 suite: pod service account name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should assign serviceAccount to primary pod
     set:
@@ -27,11 +29,11 @@ tests:
       - documentIndex: *cronJobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *cronJobDoc
         equal:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &otherDeploymentDoc 2
         isKind:
           of: Deployment
@@ -65,14 +67,14 @@ tests:
       - documentIndex: *deploymentDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &otherDeploymentDoc 2
         isKind:
           of: Deployment
       - documentIndex: *otherDeploymentDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
 
   - it: should assign serviceAccount to selected pods
     set:
@@ -105,14 +107,14 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &otherDeploymentDoc 3
         isKind:
           of: Deployment
       - documentIndex: *otherDeploymentDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test-sa-name2
+          value: test-release-name-common-test-sa-name2
 
   - it: should assign serviceAccount to selected pods
     set:
@@ -141,14 +143,14 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &otherDeploymentDoc 2
         isKind:
           of: Deployment
       - documentIndex: *otherDeploymentDoc
         equal:
           path: spec.template.spec.serviceAccountName
-          value: release-name-common-test
+          value: test-release-name-common-test
 
   # Failures
   - it: should fail with more than 1 SA assigned to a pod

--- a/library/common-test/tests/pod/share_process_namespace_test.yaml
+++ b/library/common-test/tests/pod/share_process_namespace_test.yaml
@@ -1,6 +1,8 @@
 suite: pod shareProcessNamespace test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with shareProcessNamespace disabled from "global"
     set:

--- a/library/common-test/tests/pod/termination_grace_period_test.yaml
+++ b/library/common-test/tests/pod/termination_grace_period_test.yaml
@@ -1,6 +1,8 @@
 suite: pod termination grace period test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty terminationGracePeriodSeconds
     set:

--- a/library/common-test/tests/pod/tolerations_test.yaml
+++ b/library/common-test/tests/pod/tolerations_test.yaml
@@ -1,6 +1,8 @@
 suite: pod tolerations test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with empty tolerations
     set:

--- a/library/common-test/tests/pod/volume_configmap_test.yaml
+++ b/library/common-test/tests/pod/volume_configmap_test.yaml
@@ -1,6 +1,8 @@
 suite: pod configmap volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with configmap volume
     set:
@@ -33,7 +35,7 @@ tests:
           content:
             name: conf-vol
             configMap:
-              name: release-name-common-test-some-object-name
+              name: test-release-name-common-test-some-object-name
               defaultMode: 0777
               optional: false
 
@@ -71,7 +73,7 @@ tests:
           content:
             name: conf-vol
             configMap:
-              name: release-name-common-test-some-object-name
+              name: test-release-name-common-test-some-object-name
               defaultMode: 0777
               optional: false
               items:
@@ -132,7 +134,7 @@ tests:
           content:
             name: configmap-vol
             configMap:
-              name: release-name-common-test-some-non-existent-object
+              name: test-release-name-common-test-some-non-existent-object
               optional: true
 
 # Failures

--- a/library/common-test/tests/pod/volume_device_test.yaml
+++ b/library/common-test/tests/pod/volume_device_test.yaml
@@ -1,6 +1,8 @@
 suite: pod device volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with device volume
     set:

--- a/library/common-test/tests/pod/volume_emptyDIr_test.yaml
+++ b/library/common-test/tests/pod/volume_emptyDIr_test.yaml
@@ -1,6 +1,8 @@
 suite: pod emptyDir volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with emptyDir volume
     set:

--- a/library/common-test/tests/pod/volume_hostPath_test.yaml
+++ b/library/common-test/tests/pod/volume_hostPath_test.yaml
@@ -1,6 +1,8 @@
 suite: pod hostPath volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with hostPath volume
     set:

--- a/library/common-test/tests/pod/volume_ixVolume_test.yaml
+++ b/library/common-test/tests/pod/volume_ixVolume_test.yaml
@@ -1,6 +1,8 @@
 suite: pod ixVolume volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with ixVolume volume
     set:

--- a/library/common-test/tests/pod/volume_nfs_test.yaml
+++ b/library/common-test/tests/pod/volume_nfs_test.yaml
@@ -1,6 +1,8 @@
 suite: pod nfs volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with nfs volume
     set:

--- a/library/common-test/tests/pod/volume_pvc_test.yaml
+++ b/library/common-test/tests/pod/volume_pvc_test.yaml
@@ -1,6 +1,8 @@
 suite: pod pvc volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with pvc volume
     set:
@@ -24,7 +26,7 @@ tests:
           content:
             name: pvc-vol
             persistentVolumeClaim:
-              claimName: release-name-common-test-pvc-vol
+              claimName: test-release-name-common-test-pvc-vol
 
   - it: should pass with pvc volume with existing claim
     set:

--- a/library/common-test/tests/pod/volume_secret_test.yaml
+++ b/library/common-test/tests/pod/volume_secret_test.yaml
@@ -1,6 +1,8 @@
 suite: pod secret volume test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with secret volume
     set:
@@ -33,7 +35,7 @@ tests:
           content:
             name: secret-vol
             secret:
-              secretName: release-name-common-test-some-object-name
+              secretName: test-release-name-common-test-some-object-name
               defaultMode: 0777
               optional: false
 
@@ -71,7 +73,7 @@ tests:
           content:
             name: secret-vol
             secret:
-              secretName: release-name-common-test-some-object-name
+              secretName: test-release-name-common-test-some-object-name
               defaultMode: 0777
               optional: false
               items:
@@ -132,7 +134,7 @@ tests:
           content:
             name: secret-vol
             secret:
-              secretName: release-name-common-test-some-non-existent-object
+              secretName: test-release-name-common-test-some-non-existent-object
               optional: true
 
 # Failures

--- a/library/common-test/tests/rbac/data_test.yaml
+++ b/library/common-test/tests/rbac/data_test.yaml
@@ -1,6 +1,8 @@
 suite: rbac data test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with rules and subjects added with tpl and primary rbac/sa
     set:
@@ -49,7 +51,7 @@ tests:
       - documentIndex: *roleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *roleDoc
         equal:
           path: rules
@@ -72,13 +74,13 @@ tests:
       - documentIndex: *roleBinding
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *roleBinding
         equal:
           path: subjects
           value:
             - kind: ServiceAccount
-              name: release-name-common-test
+              name: test-release-name-common-test
               namespace: NAMESPACE
             - kind: a-kind
               name: a-name
@@ -144,7 +146,7 @@ tests:
       - documentIndex: *clusterRoleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac2
+          value: test-release-name-common-test-my-rbac2
       - documentIndex: *clusterRoleDoc
         equal:
           path: rules
@@ -167,16 +169,16 @@ tests:
       - documentIndex: *clusterRoleBinding
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac2
+          value: test-release-name-common-test-my-rbac2
       - documentIndex: *clusterRoleBinding
         equal:
           path: subjects
           value:
             - kind: ServiceAccount
-              name: release-name-common-test-my-other-sa
+              name: test-release-name-common-test-my-other-sa
               namespace: NAMESPACE
             - kind: ServiceAccount
-              name: release-name-common-test
+              name: test-release-name-common-test
               namespace: NAMESPACE
             - apiGroup: rbac.authorization.k8s.io
               kind: a-kind
@@ -223,7 +225,7 @@ tests:
       - documentIndex: *roleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac3
+          value: test-release-name-common-test-my-rbac3
       - documentIndex: *roleDoc
         equal:
           path: rules
@@ -240,11 +242,11 @@ tests:
       - documentIndex: *roleBinding
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac3
+          value: test-release-name-common-test-my-rbac3
       - documentIndex: *roleBinding
         equal:
           path: subjects
           value:
             - kind: ServiceAccount
-              name: release-name-common-test-my-other-sa
+              name: test-release-name-common-test-my-other-sa
               namespace: NAMESPACE

--- a/library/common-test/tests/rbac/metadata_test.yaml
+++ b/library/common-test/tests/rbac/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with rbac created with labels and annotations
     set:
@@ -77,11 +79,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -104,11 +106,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -131,11 +133,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -158,11 +160,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/rbac/name_test.yaml
+++ b/library/common-test/tests/rbac/name_test.yaml
@@ -1,6 +1,8 @@
 suite: rbac name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -50,7 +52,7 @@ tests:
       - documentIndex: *roleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &roleBindingDoc 2
         isKind:
           of: RoleBinding
@@ -60,7 +62,7 @@ tests:
       - documentIndex: *roleBindingDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
 
       - documentIndex: &clusterRoleDoc 3
         isKind:
@@ -71,7 +73,7 @@ tests:
       - documentIndex: *clusterRoleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac2
+          value: test-release-name-common-test-my-rbac2
       - documentIndex: &clusterRoleBindingDoc 4
         isKind:
           of: ClusterRoleBinding
@@ -81,7 +83,7 @@ tests:
       - documentIndex: *clusterRoleBindingDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac2
+          value: test-release-name-common-test-my-rbac2
 
       - documentIndex: &otherRoleDoc 5
         isKind:
@@ -92,7 +94,7 @@ tests:
       - documentIndex: *otherRoleDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac3
+          value: test-release-name-common-test-my-rbac3
       - documentIndex: &otherRoleBindingDoc 6
         isKind:
           of: RoleBinding
@@ -102,4 +104,4 @@ tests:
       - documentIndex: *otherRoleBindingDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-rbac3
+          value: test-release-name-common-test-my-rbac3

--- a/library/common-test/tests/rbac/validation_test.yaml
+++ b/library/common-test/tests/rbac/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: rbac validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -13,7 +15,7 @@ tests:
           primary: false
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-rbac-has-super-long-name-that-is-longer-than-63-characters-too-bad] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-rbac-has-super-long-name-that-is-longer-than-63-characters-too-bad] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -33,7 +35,7 @@ tests:
           primary: false
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-rbac2] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-rbac2] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/secret/data_test.yaml
+++ b/library/common-test/tests/secret/data_test.yaml
@@ -1,6 +1,8 @@
 suite: secret data test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with key-value data
     set:

--- a/library/common-test/tests/secret/metadata_test.yaml
+++ b/library/common-test/tests/secret/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with secret created with labels and annotations
     set:
@@ -45,11 +47,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/secret/name_test.yaml
+++ b/library/common-test/tests/secret/name_test.yaml
@@ -1,6 +1,8 @@
 suite: secret name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -23,7 +25,7 @@ tests:
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-secret1
+          value: test-release-name-common-test-my-secret1
       - documentIndex: &otherSecretDoc 1
         isKind:
           of: Secret
@@ -33,4 +35,4 @@ tests:
       - documentIndex: *otherSecretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-secret2
+          value: test-release-name-common-test-my-secret2

--- a/library/common-test/tests/secret/validation_test.yaml
+++ b/library/common-test/tests/secret/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: secret validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -11,7 +13,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -22,7 +24,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/service/cluster_ip_test.yaml
+++ b/library/common-test/tests/service/cluster_ip_test.yaml
@@ -1,6 +1,8 @@
 suite: service clusterIP test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with type ClusterIP
     set:
@@ -30,7 +32,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -43,7 +45,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -121,6 +123,6 @@ tests:
               protocol: TCP
               targetPort: 12346
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload

--- a/library/common-test/tests/service/external_ip_test.yaml
+++ b/library/common-test/tests/service/external_ip_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with type externalIP and useSlice unset (default)
     set:
@@ -27,7 +29,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -110,20 +112,20 @@ tests:
       - documentIndex: *endpointSliceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *endpointSliceDoc
         equal:
           path: metadata.labels
           value:
-            kubernetes.io/service-name: release-name-common-test
+            kubernetes.io/service-name: test-release-name-common-test
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             helm.sh/chart: common-test-1.0.0
             helm-revision: "0"
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
       - documentIndex: *endpointSliceDoc
         equal:
           path: addressType
@@ -295,19 +297,19 @@ tests:
       - documentIndex: *endpointDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *endpointDoc
         equal:
           path: metadata.labels
           value:
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             helm.sh/chart: common-test-1.0.0
             helm-revision: "0"
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
       - documentIndex: *endpointDoc
         equal:
           path: subsets

--- a/library/common-test/tests/service/external_name_test.yaml
+++ b/library/common-test/tests/service/external_name_test.yaml
@@ -1,6 +1,8 @@
 suite: service externalName test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with type externalName
     set:
@@ -25,7 +27,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -57,7 +59,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec

--- a/library/common-test/tests/service/list_test.yaml
+++ b/library/common-test/tests/service/list_test.yaml
@@ -1,6 +1,8 @@
 suite: service list test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with type LoadBalancer from serviceList with name
     set:
@@ -35,7 +37,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -49,7 +51,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
       - documentIndex: &otherServiceDoc 2
@@ -61,7 +63,7 @@ tests:
       - documentIndex: *otherServiceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-service2
+          value: test-release-name-common-test-my-service2
       - documentIndex: *otherServiceDoc
         equal:
           path: spec
@@ -75,7 +77,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -103,7 +105,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -117,7 +119,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -145,7 +147,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -158,7 +160,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -193,7 +195,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -214,7 +216,7 @@ tests:
               protocol: TCP
               targetPort: 12346
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -250,7 +252,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -271,6 +273,6 @@ tests:
               protocol: TCP
               targetPort: 12346
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload

--- a/library/common-test/tests/service/load_balancer_test.yaml
+++ b/library/common-test/tests/service/load_balancer_test.yaml
@@ -1,6 +1,8 @@
 suite: service loadBalancer test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with type LoadBalancer
     set:
@@ -30,7 +32,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -44,7 +46,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -136,6 +138,6 @@ tests:
               protocol: TCP
               targetPort: 12346
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload

--- a/library/common-test/tests/service/metadata_test.yaml
+++ b/library/common-test/tests/service/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with service created with labels and annotations
     set:
@@ -63,12 +65,12 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test
             service.name: my-service1
             g_label1: global_label1
@@ -84,7 +86,7 @@ tests:
           value:
             service.name: my-service2
             app: common-test-1.0.0
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
@@ -92,7 +94,7 @@ tests:
             g_label2: global_label2
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
 
   - it: should pass with service type LoadBalancer, with https port and addMetalLBAnnotations/Traefik true
     set:
@@ -125,7 +127,7 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/allow-shared-ip: release-name-common-test
+            metallb.universe.tf/allow-shared-ip: test-release-name-common-test
             traefik.ingress.kubernetes.io/service.serversscheme: https
 
   - it: should pass with correct selector with targetSelector
@@ -156,7 +158,7 @@ tests:
           value:
             pod.name: my-workload
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
 
   - it: should pass with correct selector without targetSelector
     set:
@@ -189,4 +191,4 @@ tests:
           value:
             pod.name: my-workload
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name

--- a/library/common-test/tests/service/names_test.yaml
+++ b/library/common-test/tests/service/names_test.yaml
@@ -1,6 +1,8 @@
 suite: service name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -44,7 +46,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &otherServiceDoc 2
         isKind:
           of: Service
@@ -54,7 +56,7 @@ tests:
       - documentIndex: *otherServiceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-service2
+          value: test-release-name-common-test-my-service2
       - documentIndex: &thirdServiceDoc 3
         isKind:
           of: Service

--- a/library/common-test/tests/service/node_port_test.yaml
+++ b/library/common-test/tests/service/node_port_test.yaml
@@ -1,6 +1,8 @@
 suite: service nodePort test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with type nodePort
     set:
@@ -31,7 +33,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -45,7 +47,7 @@ tests:
               targetPort: 12345
               nodePort: 30000
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
 
@@ -79,7 +81,7 @@ tests:
       - documentIndex: *serviceDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *serviceDoc
         equal:
           path: spec
@@ -92,7 +94,7 @@ tests:
               protocol: TCP
               targetPort: 12345
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
       - documentIndex: *serviceDoc
@@ -180,6 +182,6 @@ tests:
               targetPort: 12346
               nodePort: 30001
             selector:
-              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload

--- a/library/common-test/tests/service/validation_test.yaml
+++ b/library/common-test/tests/service/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: service validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail without primary service
     set:

--- a/library/common-test/tests/serviceAccount/metadata_test.yaml
+++ b/library/common-test/tests/serviceAccount/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with service account created with labels and annotations
     set:
@@ -44,11 +46,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1

--- a/library/common-test/tests/serviceAccount/name_test.yaml
+++ b/library/common-test/tests/serviceAccount/name_test.yaml
@@ -1,6 +1,8 @@
 suite: service account name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:
@@ -22,7 +24,7 @@ tests:
       - documentIndex: *primaryServiceAccount
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: &serviceAccount 1
         isKind:
           of: ServiceAccount
@@ -32,7 +34,7 @@ tests:
       - documentIndex: *serviceAccount
         equal:
           path: metadata.name
-          value: release-name-common-test-my-sa1
+          value: test-release-name-common-test-my-sa1
       - documentIndex: &otherServiceAccount 2
         isKind:
           of: ServiceAccount
@@ -42,4 +44,4 @@ tests:
       - documentIndex: *otherServiceAccount
         equal:
           path: metadata.name
-          value: release-name-common-test-my-sa2
+          value: test-release-name-common-test-my-sa2

--- a/library/common-test/tests/serviceAccount/validation_test.yaml
+++ b/library/common-test/tests/serviceAccount/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: service account validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -13,7 +15,7 @@ tests:
           primary: false
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-my-service-account-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-service-account-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -26,7 +28,7 @@ tests:
           primary: false
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_my-sa2] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-sa2] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/statefulset/metadata_test.yaml
+++ b/library/common-test/tests/statefulset/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with statefulset created with labels and annotations
     set:
@@ -52,11 +54,11 @@ tests:
           path: metadata.labels
           value:
             app: common-test-1.0.0
-            release: RELEASE-NAME
+            release: test-release-name
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: *appVer
             g_label1: global_label1
@@ -69,15 +71,15 @@ tests:
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *statefulSetDoc
         equal:
           path: spec.template.metadata.labels
           value:
             pod.name: workload-name
             app: common-test-1.0.0
-            release: RELEASE-NAME
-            app.kubernetes.io/instance: RELEASE-NAME
+            release: test-release-name
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: v9.9.9
@@ -112,20 +114,20 @@ tests:
       - documentIndex: *statefulSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-other-workload-name
+          value: test-release-name-common-test-other-workload-name
       - documentIndex: *statefulSetDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: other-workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *statefulSetDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: other-workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test
       - documentIndex: &otherStatefulSetDoc 1
         isKind:
@@ -133,18 +135,18 @@ tests:
       - documentIndex: *otherStatefulSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test
       - documentIndex: *otherStatefulSetDoc
         equal:
           path: spec.selector.matchLabels
           value:
             pod.name: workload-name
             app.kubernetes.io/name: common-test
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
       - documentIndex: *otherStatefulSetDoc
         isSubset:
           path: spec.template.metadata.labels
           content:
             pod.name: workload-name
-            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/name: common-test

--- a/library/common-test/tests/statefulset/spec_test.yaml
+++ b/library/common-test/tests/statefulset/spec_test.yaml
@@ -1,6 +1,8 @@
 suite: statefulset spec test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should pass with workload enabled
     set:

--- a/library/common-test/tests/statefulset/validation_test.yaml
+++ b/library/common-test/tests/statefulset/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: statefulset validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with invalid strategy
     set:

--- a/library/common-test/tests/volumeClaimTemplate/metadata_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/metadata_test.yaml
@@ -3,6 +3,8 @@ templates:
   - common.yaml
 chart:
   appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
 tests:
   - it: should pass with vct created with labels and annotations
     set:

--- a/library/common-test/tests/volumeClaimTemplate/names_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/names_test.yaml
@@ -1,6 +1,8 @@
 suite: volumeClaimTemplates name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct name
     set:

--- a/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: volumeClaimTemplates validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with annotations not a dict
     set:

--- a/library/common-test/tests/volumeClaimTemplate/vct_data_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/vct_data_test.yaml
@@ -1,6 +1,8 @@
 suite: volumeClaimTemplates data name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should create vct
     set:

--- a/library/common-test/tests/workload/names_test.yaml
+++ b/library/common-test/tests/workload/names_test.yaml
@@ -1,6 +1,8 @@
 suite: workload name test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should generate correct workload name
     set:
@@ -41,7 +43,7 @@ tests:
       - documentIndex: *cronJobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-cronjob-workload-name
+          value: test-release-name-common-test-cronjob-workload-name
       - documentIndex: &daemonSetDoc 1
         isKind:
           of: DaemonSet
@@ -51,7 +53,7 @@ tests:
       - documentIndex: *daemonSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-daemonset-workload-name
+          value: test-release-name-common-test-daemonset-workload-name
       - documentIndex: &jobDoc 2
         isKind:
           of: Job
@@ -61,7 +63,7 @@ tests:
       - documentIndex: *jobDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-job-workload-name
+          value: test-release-name-common-test-job-workload-name
       - documentIndex: &statefulSetDoc 3
         isKind:
           of: StatefulSet
@@ -71,7 +73,7 @@ tests:
       - documentIndex: *statefulSetDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-stateful-workload-name
+          value: test-release-name-common-test-stateful-workload-name
       - documentIndex: &deploymentDoc 4
         isKind:
           of: Deployment
@@ -81,4 +83,4 @@ tests:
       - documentIndex: *deploymentDoc
         equal:
           path: metadata.name
-          value: release-name-common-test
+          value: test-release-name-common-test

--- a/library/common-test/tests/workload/validation_test.yaml
+++ b/library/common-test/tests/workload/validation_test.yaml
@@ -1,6 +1,8 @@
 suite: workload validation test
 templates:
   - common.yaml
+release:
+  name: test-release-name
 tests:
   - it: should fail with name longer than 63 characters
     set:
@@ -17,7 +19,7 @@ tests:
           podSpec: {}
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-other-workload-name-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-other-workload-name-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -34,7 +36,7 @@ tests:
           podSpec: {}
     asserts:
       - failedTemplate:
-          errorMessage: Name [release-name-common-test-_other-workload-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_other-workload-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with invalid type
     set:

--- a/library/common/templates/lib/metadata/_externalInterfaceAnnotations.tpl
+++ b/library/common/templates/lib/metadata/_externalInterfaceAnnotations.tpl
@@ -29,7 +29,7 @@ objectData is object containing the data of the pod
   {{- if $rootCtx.Values.ixExternalInterfacesConfiguration -}}
     {{- with $rootCtx.Values.ixExternalInterfacesConfigurationNames -}}
       {{- range $ifaceName := . -}}
-        {{/* Get the index by splitting the iFaceName (ix-RELEASE-NAME-0) */}}
+        {{/* Get the index by splitting the iFaceName (ix-release-name-0) */}}
         {{- $index := splitList "-" $ifaceName -}}
         {{/* And pick the last item on the list */}}
         {{- $index = mustLast $index -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Setting explicitly the release name on tests helps make the tests more stable.
While I was working on #441 I've noticed that the `.Release.Namespace` coming from the unit test package was in CAPS. 
Which is not a valid namespace, same is happening `.Release.Name`.
Adapting tests now, to avoid future unexpected failed tests

Only reason this was not failing, even if we have a validation in place. is that the `.Release.Name` is not used anywhere directly, but only through the fullname function which `lower`s it

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
