### PR TITLE
fix: imagePullSecret registry value

### DIFF
--- a/library/common-test/tests/imagePullSecret/data_test.yaml
+++ b/library/common-test/tests/imagePullSecret/data_test.yaml
@@ -23,7 +23,7 @@ tests:
         equal:
           path: data
           value:
-            .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeSI6eyJhdXRoIjoiZFhObGNqcHdZWE56IiwiZW1haWwiOiJtYWlsIiwicGFzc3dvcmQiOiJwYXNzIiwidXNlcm5hbWUiOiJ1c2VyIn19fQ==
+            .dockerconfigjson: eyJhdXRocyI6eyJyZWciOnsiYXV0aCI6ImRYTmxjanB3WVhOeiIsImVtYWlsIjoibWFpbCIsInBhc3N3b3JkIjoicGFzcyIsInVzZXJuYW1lIjoidXNlciJ9fX0=
       - documentIndex: *secretDoc
         equal:
           path: type
@@ -48,4 +48,4 @@ tests:
         equal:
           path: data
           value:
-            .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeSI6eyJhdXRoIjoiZFhObGNqcHpaV055WlhSZmNHRnpjdz09IiwiZW1haWwiOiJtYWlsQGV4YW1wbGUuY29tIiwicGFzc3dvcmQiOiJzZWNyZXRfcGFzcyIsInVzZXJuYW1lIjoidXNlciJ9fX0=
+            .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7ImF1dGgiOiJkWE5sY2pwelpXTnlaWFJmY0dGemN3PT0iLCJlbWFpbCI6Im1haWxAZXhhbXBsZS5jb20iLCJwYXNzd29yZCI6InNlY3JldF9wYXNzIiwidXNlcm5hbWUiOiJ1c2VyIn19fQ==

--- a/library/common/templates/lib/imagePullSecret/_createData.tpl
+++ b/library/common/templates/lib/imagePullSecret/_createData.tpl
@@ -21,7 +21,7 @@ objectData:
                             "email" (tpl .email $rootCtx) "auth" $auth) -}}
   {{- end -}}
 
-  {{- $_ := set $registrySecret "auths" (dict "registry" $registry) -}}
+  {{- $_ := set $registrySecret "auths" (dict (tpl $objectData.data.registry $rootCtx) $registry) -}}
 
   {{/*
   This should result in something like this:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #520

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
```shell
helm unittest -f tests/imagePullSecret/data_test.yaml library/common-test
```

**📃 Notes:**

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`
