### PR TITLE
fix(name-checks): allow 253 chars in configmap/secrets

### DIFF
--- a/library/common-test/tests/certificate/validation_test.yaml
+++ b/library/common-test/tests/certificate/validation_test.yaml
@@ -5,15 +5,15 @@ release:
   name: test-release-name
   namespace: test-release-namespace
 tests:
-  - it: should fail with name longer than 63 characters
+  - it: should fail with name longer than 253 characters
     set:
       scaleCertificate:
-        my-certificate-super-long-name-that-is-longer-than-63-characters:
+        my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-long-long-long-long-long-name:
           enabled: true
           id: 1
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-my-certificate-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-name-that-is-longer-than-253-characters-my-certificate-super-long-long-long-long-long-long-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -23,7 +23,7 @@ tests:
           id: 1
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-_my-cert] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-cert] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with labels not a dict
     set:

--- a/library/common-test/tests/configmap/validation_test.yaml
+++ b/library/common-test/tests/configmap/validation_test.yaml
@@ -5,16 +5,16 @@ release:
   name: test-release-name
   namespace: test-release-namespace
 tests:
-  - it: should fail with name longer than 63 characters
+  - it: should fail with name longer than 253 characters
     set:
       configmap:
-        my-configmap-super-long-name-that-is-longer-than-63-characters:
+        my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-long-long-long-long-long-long-long-name:
           enabled: true
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-my-configmap-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-name-that-is-longer-than-253-characters-my-configmap-super-long-long-long-long-long-long-long-long-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -25,19 +25,19 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-_my-configmap] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-configmap] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
-  - it: should fail with namespace longer than 63 characters
+  - it: should fail with namespace longer than 253 characters
     set:
       configmap:
         my-configmap:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Configmap - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Configmap - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common-test/tests/configmap/validation_test.yaml
+++ b/library/common-test/tests/configmap/validation_test.yaml
@@ -27,17 +27,17 @@ tests:
       - failedTemplate:
           errorMessage: Name [test-release-name-common-test-_my-configmap] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
-  - it: should fail with namespace longer than 253 characters
+  - it: should fail with namespace longer than 63 characters
     set:
       configmap:
         my-configmap:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Configmap - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
+          errorMessage: Configmap - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common-test/tests/imagePullSecret/validation_test.yaml
+++ b/library/common-test/tests/imagePullSecret/validation_test.yaml
@@ -131,12 +131,12 @@ tests:
       - failedTemplate:
           errorMessage: Image Pull Secret - Expected non-empty <email>
 
-  - it: should fail with namespace longer than 253 characters
+  - it: should fail with namespace longer than 63 characters
     set:
       imagePullSecret:
         my-secret1:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
           data:
             registry: reg
             username: user
@@ -144,7 +144,7 @@ tests:
             email: mail
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
+          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common-test/tests/imagePullSecret/validation_test.yaml
+++ b/library/common-test/tests/imagePullSecret/validation_test.yaml
@@ -5,10 +5,10 @@ release:
   name: test-release-name
   namespace: test-release-namespace
 tests:
-  - it: should fail with name longer than 63 characters
+  - it: should fail with name longer than 253 characters
     set:
       imagePullSecret:
-        my-pull-secret-super-long-name-that-is-longer-than-63-characters:
+        my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-long-long-long-long-long-name:
           enabled: true
           data: &data
             registry: reg
@@ -17,7 +17,7 @@ tests:
             email: mail
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-my-pull-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-name-that-is-longer-than-253-characters-my-pull-secret-super-long-long-long-long-long-long-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -27,7 +27,7 @@ tests:
           data: *data
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-_my-pull-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-pull-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with labels not a dict
     set:
@@ -131,12 +131,12 @@ tests:
       - failedTemplate:
           errorMessage: Image Pull Secret - Expected non-empty <email>
 
-  - it: should fail with namespace longer than 63 characters
+  - it: should fail with namespace longer than 253 characters
     set:
       imagePullSecret:
         my-secret1:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
           data:
             registry: reg
             username: user
@@ -144,7 +144,7 @@ tests:
             email: mail
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common-test/tests/secret/validation_test.yaml
+++ b/library/common-test/tests/secret/validation_test.yaml
@@ -51,17 +51,17 @@ tests:
       - failedTemplate:
           errorMessage: Secret - Expected <annotations> to be a dictionary, but got [string]
 
-  - it: should fail with namespace longer than 253 characters
+  - it: should fail with namespace longer than 63 characters
     set:
       secret:
         my-secret:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
+          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common-test/tests/secret/validation_test.yaml
+++ b/library/common-test/tests/secret/validation_test.yaml
@@ -5,16 +5,16 @@ release:
   name: test-release-name
   namespace: test-release-namespace
 tests:
-  - it: should fail with name longer than 63 characters
+  - it: should fail with name longer than 253 characters
     set:
       secret:
-        my-secret-super-long-name-that-is-longer-than-63-characters:
+        my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-long-long-long-long-long-long-long-long-long-name:
           enabled: true
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-my-secret-super-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-name-that-is-longer-than-253-characters-my-secret-super-long-long-long-long-long-long-long-long-long-long-name] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with name starting with underscore
     set:
@@ -25,7 +25,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Name [test-release-name-common-test-_my-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Name [test-release-name-common-test-_my-secret] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with labels not a dict
     set:
@@ -51,17 +51,17 @@ tests:
       - failedTemplate:
           errorMessage: Secret - Expected <annotations> to be a dictionary, but got [string]
 
-  - it: should fail with namespace longer than 63 characters
+  - it: should fail with namespace longer than 253 characters
     set:
       secret:
         my-secret:
           enabled: true
-          namespace: my-extra-super-duper-long-name-that-is-longer-than-63-characters
+          namespace: my-extra-super-duper-long-name-that-is-longer-than-253-characters
           data:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-63-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
+          errorMessage: Secret - Namespace [my-extra-super-duper-long-name-that-is-longer-than-253-characters] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 253 characters.
 
   - it: should fail with namespace not starting with [ix-] in TrueNAS SCALE
     set:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.0.7
+version: 14.0.8

--- a/library/common/templates/lib/chart/_names.tpl
+++ b/library/common/templates/lib/chart/_names.tpl
@@ -33,9 +33,13 @@
 {{- define "tc.v1.common.lib.chart.names.validation" -}}
 
   {{- $name := .name -}}
+  {{- $length := .length -}}
+  {{- if not $length -}}
+    {{- $length = 63 -}}
+  {{- end -}}
 
-  {{- if not (and (mustRegexMatch "^[a-z0-9](-?[a-z0-9]-?)+[a-z0-9]$" $name) (le (len $name) 63)) -}}
-    {{- fail (printf "Name [%s] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters." $name) -}}
+  {{- if not (and (mustRegexMatch "^[a-z0-9](-?[a-z0-9]-?)+[a-z0-9]$" $name) (le (len $name) $length)) -}}
+    {{- fail (printf "Name [%s] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most %v characters." $name $length) -}}
   {{- end -}}
 
 {{- end -}}

--- a/library/common/templates/spawner/_configmap.tpl
+++ b/library/common/templates/spawner/_configmap.tpl
@@ -41,8 +41,8 @@
         {{- end -}}
       {{- end -}}
 
-      {{/* Perform validations */}}
-      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName) -}}
+      {{/* Perform validations */}} {{/* Configmaps have a max name length of 253 */}}
+      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
       {{- include "tc.v1.common.lib.configmap.validation" (dict "objectData" $objectData) -}}
       {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $objectData "caller" "ConfigMap") -}}
 

--- a/library/common/templates/spawner/_imagePullSecret.tpl
+++ b/library/common/templates/spawner/_imagePullSecret.tpl
@@ -15,8 +15,8 @@
 
       {{- $objectName := (printf "%s-%s" $fullname $name) -}}
 
-      {{/* Perform validations */}}
-      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName) -}}
+      {{/* Perform validations */}} {{/* Secrets have a max name length of 253 */}}
+      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
       {{- include "tc.v1.common.lib.imagePullSecret.validation" (dict "objectData" $objectData) -}}
       {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $objectData "caller" "Image Pull Secret") -}}
       {{- $data := include "tc.v1.common.lib.imagePullSecret.createData" (dict "rootCtx" $ "objectData" $objectData) -}}

--- a/library/common/templates/spawner/_portal.tpl
+++ b/library/common/templates/spawner/_portal.tpl
@@ -151,8 +151,8 @@
         {{- $objectName := ( printf "tcportal-%s" $name ) -}}
         {{- $configMap := dict "enabled" true "name" $objectName "shortName" $objectName "data" $portalData -}}
 
-        {{/* Perform validations */}}
-        {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName) -}}
+        {{/* Perform validations */}} {{/* Configmaps have a max name length of 253 */}}
+        {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
         {{- include "tc.v1.common.lib.configmap.validation" (dict "objectData" $configMap) -}}
         {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $configMap "caller" "ConfigMap") -}}
 

--- a/library/common/templates/spawner/_scaleCertificate.tpl
+++ b/library/common/templates/spawner/_scaleCertificate.tpl
@@ -14,8 +14,8 @@
       {{- $objectData := (mustDeepCopy $certificate) -}}
 
       {{- $objectName := (printf "%s-%s" $fullname $name) -}}
-      {{/* Perform validations */}}
-      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName) -}}
+      {{/* Perform validations */}} {{/* Secrets have a max name length of 253 */}}
+      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
       {{- include "tc.v1.common.lib.scaleCertificate.validation" (dict "objectData" $objectData) -}}
       {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $objectData "caller" "Certificate") -}}
 

--- a/library/common/templates/spawner/_secret.tpl
+++ b/library/common/templates/spawner/_secret.tpl
@@ -40,8 +40,8 @@
         {{- end -}}
       {{- end -}}
 
-      {{/* Perform validations */}}
-      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName) -}}
+      {{/* Perform validations */}} {{/* Secrets have a max name length of 253 */}}
+      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
       {{- include "tc.v1.common.lib.secret.validation" (dict "objectData" $objectData) -}}
       {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $objectData "caller" "Secret") -}}
 


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
