### PR TITLE
feat(certificates): Add secretTemplate to certificate CRD

### DIFF
--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -30,5 +30,5 @@ spec:
     group: cert-manager.io
   secretTemplate:
   {{- $secretTemplate := ($certificateSecretTemplate | default dict) }}
-  {{- $secretTemplate | nindent 4 }}
+  {{- $secretTemplate | toYaml | nindent 4 }}
 {{- end -}}

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -30,6 +30,16 @@ spec:
     group: cert-manager.io
   {{- if $certificateSecretTemplate }}
   secretTemplate:
-    {{- $certificateSecretTemplate | toYaml | nindent 4 }}
-  {{- end -}}
+    {{- $labels := (mustMerge ($certificateSecretTemplate.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $root | fromYaml)) -}}
+    {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $root "labels" $labels) | trim) }}
+  labels:
+      {{- . | nindent 4 }}
+    {{- end -}}
+    {{- $annotations := (mustMerge ($certificateSecretTemplate.annotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $root | fromYaml)) -}}
+    {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $root "annotations" $annotations) | trim) }}
+  annotations:
+      {{- . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
 {{- end -}}

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -28,7 +28,8 @@ spec:
     name: {{ tpl $certificateIssuer $root | quote }}
     kind: ClusterIssuer
     group: cert-manager.io
+  {{ if $certificateSecretTemplate }}
   secretTemplate:
-  {{- $secretTemplate := ($certificateSecretTemplate | default dict) }}
-  {{- $secretTemplate | toYaml | nindent 4 }}
+    {{- $certificateSecretTemplate | toYaml | nindent 4 }}
+  {{- end -}}
 {{- end -}}

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -28,7 +28,7 @@ spec:
     name: {{ tpl $certificateIssuer $root | quote }}
     kind: ClusterIssuer
     group: cert-manager.io
-  {{ if $certificateSecretTemplate }}
+  {{- if $certificateSecretTemplate }}
   secretTemplate:
     {{- $certificateSecretTemplate | toYaml | nindent 4 }}
   {{- end -}}

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -32,13 +32,13 @@ spec:
   secretTemplate:
     {{- $labels := (mustMerge ($certificateSecretTemplate.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $root | fromYaml)) -}}
     {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $root "labels" $labels) | trim) }}
-  labels:
-      {{- . | nindent 4 }}
+    labels:
+      {{- . | nindent 6 }}
     {{- end -}}
     {{- $annotations := (mustMerge ($certificateSecretTemplate.annotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $root | fromYaml)) -}}
     {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $root "annotations" $annotations) | trim) }}
-  annotations:
-      {{- . | nindent 4 }}
+    annotations:
+      {{- . | nindent 6 }}
     {{- end }}
   {{- end }}
 

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -7,6 +7,7 @@ within the common library.
 {{- $name := .name -}}
 {{- $hosts := .hosts -}}
 {{- $certificateIssuer := .certificateIssuer }}
+{{- $certificateSecretTemplate := .secretTemplate -}}
 ---
 apiVersion: {{ include "tc.v1.common.capabilities.cert-manager.certificate.apiVersion" $ }}
 kind: Certificate
@@ -27,6 +28,7 @@ spec:
     name: {{ tpl $certificateIssuer $root | quote }}
     kind: ClusterIssuer
     group: cert-manager.io
-
-
+  secretTemplate:
+  {{- $secretTemplate := ($certificateSecretTemplate | default dict) }}
+  {{- $secretTemplate | nindent 4 }}
 {{- end -}}

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -6,8 +6,8 @@ within the common library.
 {{- $root := .root -}}
 {{- $name := .name -}}
 {{- $hosts := .hosts -}}
-{{- $certificateIssuer := .certificateIssuer }}
-{{- $certificateSecretTemplate := .secretTemplate -}}
+{{- $certificateIssuer := .certificateIssuer -}}
+{{- $certificateSecretTemplate := .secretTemplate }}
 ---
 apiVersion: {{ include "tc.v1.common.capabilities.cert-manager.certificate.apiVersion" $ }}
 kind: Certificate

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -39,7 +39,7 @@ spec:
     {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $root "annotations" $annotations) | trim) }}
     annotations:
       {{- . | nindent 6 }}
-    {{- end }}
-  {{- end }}
+    {{- end -}}
+  {{- end -}}
 
 {{- end -}}

--- a/library/common/templates/spawner/_certificate.tpl
+++ b/library/common/templates/spawner/_certificate.tpl
@@ -17,7 +17,7 @@
         {{- $certName = printf "%v-%v" $certName $certValues.nameOverride -}}
       {{- end -}}
 
-      {{- include "tc.v1.common.class.certificate" (dict "root" $ "name" $certName "certificateIssuer" $cert.certificateIssuer "hosts" $cert.hosts ) -}}
+      {{- include "tc.v1.common.class.certificate" (dict "root" $ "name" $certName "certificateIssuer" $cert.certificateIssuer "hosts" $cert.hosts "secretTemplate" $cert.secretTemplate ) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Adds the ability to add `secretTemplate` property to Certificate CRDs.

Related to: https://github.com/truecharts/charts/issues/8634

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Haven't explicitly tested it. See Notes.

**📃 Notes:**
<!-- Please enter any other relevant information here -->
Not sure how I can test the lib. I hope this is a simple enough change that doesn't need testing before merging.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
