### PR TITLE
feat(common): add support for clusterCertificate to ingress and readd ingresslist

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~14.1.0
+  version: ~14.2.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.1.1
+version: 14.2.0

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -125,7 +125,7 @@ spec:
         {{- $_ := set $cert "nameOverride" $tlsName }}
       secretName: {{ printf "%s-tls-%v" (include "tc.v1.common.lib.chart.names.fullname" $) $index }}
       {{- else if .clusterCertificate }}
-      secretName: clusterissuer-templated-{{ tpl .clusterCertificate $ | quote }}
+      secretName: clusterissuer-templated-{{ tpl .clusterCertificate $ }}
       {{- else if .secretName }}
       secretName: {{ tpl .secretName $ | quote }}
       {{- end -}}

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -125,7 +125,7 @@ spec:
         {{- $_ := set $cert "nameOverride" $tlsName }}
       secretName: {{ printf "%s-tls-%v" (include "tc.v1.common.lib.chart.names.fullname" $) $index }}
       {{- else if .clusterCertificate }}
-      secretName: clusterissuer-{{ tpl .clusterCertificate $ | quote }}
+      secretName: clusterissuer-templated-{{ tpl .clusterCertificate $ | quote }}
       {{- else if .secretName }}
       secretName: {{ tpl .secretName $ | quote }}
       {{- end -}}

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -124,6 +124,8 @@ spec:
         {{- $_ := set $cert "id" $tlsValues.scaleCert }}
         {{- $_ := set $cert "nameOverride" $tlsName }}
       secretName: {{ printf "%s-tls-%v" (include "tc.v1.common.lib.chart.names.fullname" $) $index }}
+      {{- else if .clusterCertificate }}
+      secretName: clusterissuer-{{ tpl .clusterCertificate $ | quote }}
       {{- else if .secretName }}
       secretName: {{ tpl .secretName $ | quote }}
       {{- end -}}

--- a/library/common/templates/loader/_lists.tpl
+++ b/library/common/templates/loader/_lists.tpl
@@ -6,4 +6,6 @@
 
   {{- include "tc.v1.common.values.serviceList" . -}}
 
+  {{- include "tc.v1.common.values.ingressList" . -}}
+
 {{- end -}}

--- a/library/common/templates/spawner/_certificate.tpl
+++ b/library/common/templates/spawner/_certificate.tpl
@@ -17,6 +17,10 @@
         {{- $certName = printf "%v-%v" $certName $certValues.nameOverride -}}
       {{- end -}}
 
+      {{- if $certValues.certificateSecretTemplate -}}
+        {{- $certName = printf "%v-%v" "clusterissuer-templated" $name -}}
+      {{- end -}}
+
       {{- include "tc.v1.common.class.certificate" (dict "root" $ "name" $certName "certificateIssuer" $cert.certificateIssuer "hosts" $cert.hosts "secretTemplate" $cert.secretTemplate ) -}}
     {{- end -}}
   {{- end -}}

--- a/library/common/templates/values/lists/_ingressList.tpl
+++ b/library/common/templates/values/lists/_ingressList.tpl
@@ -12,6 +12,6 @@
         {{- $_ := set $rootCtx.Values "ingress" dict -}}
       {{- end -}}
 
-      {{- $_ := set $rootCtx.Values.ingress $name $persistenceValues -}}
+      {{- $_ := set $rootCtx.Values.ingress $name $ingressValues -}}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/values/lists/_ingressList.tpl
+++ b/library/common/templates/values/lists/_ingressList.tpl
@@ -1,0 +1,17 @@
+{{- define "tc.v1.common.values.ingressList" -}}
+  {{- $rootCtx := . -}}
+
+  {{- range $idx, $ingressValues := $rootCtx.Values.ingressList -}}
+      {{- $name := (printf "ingress-list-%s" (toString $idx)) -}}
+
+      {{- with $ingressValues.name -}}
+        {{- $name = . -}}
+      {{- end -}}
+
+      {{- if not (hasKey $rootCtx.Values "ingress") -}}
+        {{- $_ := set $rootCtx.Values "ingress" dict -}}
+      {{- end -}}
+
+      {{- $_ := set $rootCtx.Values.ingress $name $persistenceValues -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
**Description**
- Changes the name of certificates with a secrettemplate, to make it easier to use kubernetes-reflector and ingress on those, ensures they do not include the fullname namespace of the chart creating the certificate
- readds a parser for ingressList, not sure if functional, but at least it exists on a basic level now
- Adds the ability to define clusterCertificates on ingress.tls and automatically fix/apply the secrettemplate naming scheme accordingly.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
