### PR TITLE
allow names shorter than three characters

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.2.3
+version: 14.2.4

--- a/library/common/templates/lib/chart/_names.tpl
+++ b/library/common/templates/lib/chart/_names.tpl
@@ -38,7 +38,7 @@
     {{- $length = 63 -}}
   {{- end -}}
 
-  {{- if not (and (mustRegexMatch "^[a-z0-9](-?[a-z0-9]-?)+[a-z0-9]$" $name) (le (len $name) $length)) -}}
+  {{- if not (and (mustRegexMatch "^[a-z0-9]((-?[a-z0-9]-?)*[a-z0-9])?$" $name) (le (len $name) $length)) -}}
     {{- fail (printf "Name [%s] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most %v characters." $name $length) -}}
   {{- end -}}
 

--- a/library/common/templates/lib/metadata/_namespace.tpl
+++ b/library/common/templates/lib/metadata/_namespace.tpl
@@ -17,7 +17,7 @@
     {{- $namespace = tpl . $rootCtx -}}
   {{- end -}}
 
-  {{- if not (and (mustRegexMatch "^[a-z0-9](-?[a-z0-9]-?)+[a-z0-9]$" $namespace) (le (len $namespace) 63)) -}}
+  {{- if not (and (mustRegexMatch "^[a-z0-9]((-?[a-z0-9]-?)*[a-z0-9])?$" $namespace) (le (len $namespace) 63)) -}}
     {{- fail (printf "%s - Namespace [%s] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters." $caller $namespace) -}}
   {{- end -}}
 


### PR DESCRIPTION
**Description**

It is currently not possible to render charts with namespace name shorter than 3 characters.

This PR fixes the corresponding regex in the common library chart to also allow the short valid k8s namespaces consisting of one and two alphanumeric characters.

The regression was introduced in recent [addition of namespace metadata](https://github.com/truecharts/library-charts/commit/07d4558f5e8e02c0d3d3ca48cfdfe1b2a24594a1). This PR fixes both appearances of `mustRegexMatch()`.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

```bash
helm template --namespace ha --create-namespace ha TrueCharts/home-assistant
# Error: execution error at (home-assistant/templates/common.yaml:5:3): Configmap - Namespace [ha] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
git checkout fix-short-release-name
helm template --namespace ha --create-namespace ha ./home-assistant/ | head -n2
# ---
# Source: home-assistant/templates/common.yaml
helm template --namespace ha --create-namespace h ./home-assistant/ -f values.yaml  | head -n2
# ---
# Source: home-assistant/templates/common.yaml
helm template --namespace "-a" --create-namespace h ./home-assistant/ -f values.yaml
# Error: execution error at (home-assistant/templates/common.yaml:5:3): Configmap - Namespace [-a] is not valid. Must start and end with an alphanumeric lowercase character. It can contain '-'. And must be at most 63 characters.
```

The updated regex allows one- and two-character namespaces. Validation still works, as shown above.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
