### PR TITLE
feat(common): limit default arch to AMD64, add topologySpreadConstraints and ensure solid default spread

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~14.2.0
+  version: ~14.3.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/tests/pod/node_selector_test.yaml
+++ b/library/common-test/tests/pod/node_selector_test.yaml
@@ -245,8 +245,8 @@ tests:
           value:
             disk: hdd
             cpu: amd
-  # Failures
-  - it: should fail with empty value on nodeSelector
+
+  - it: should ignore with empty value on nodeSelector
     set:
       podOptions:
         nodeSelector:
@@ -259,5 +259,8 @@ tests:
           schedule: "*/1 * * * *"
           podSpec: {}
     asserts:
-      - failedTemplate:
-          errorMessage: Expected non-empty value on <nodeSelector> [disk] key.
+      - documentIndex: *cronJobDoc
+        equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/arch: amd64

--- a/library/common-test/tests/pod/node_selector_test.yaml
+++ b/library/common-test/tests/pod/node_selector_test.yaml
@@ -5,10 +5,11 @@ release:
   name: test-release-name
   namespace: test-release-namespace
 tests:
-  - it: should pass with empty nodeSelector
+  - it: should pass without default arch set
     set:
       podOptions:
-        nodeSelector: {}
+        nodeSelector:
+          kubernetes.io/arch: ""
       workload:
         workload-name1:
           enabled: true
@@ -23,6 +24,24 @@ tests:
       - documentIndex: *cronJobDoc
         isNull:
           path: spec.jobTemplate.spec.template.spec.nodeSelector
+
+  - it: should pass with empty nodeSelector
+    set:
+      podOptions:
+        nodeSelector: {}
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: CronJob
+          schedule: "*/1 * * * *"
+          podSpec: {}
+    asserts:
+      - documentIndex: *cronJobDoc
+        equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/arch: amd64
 
   - it: should pass with nodeSelector from "global"
     set:
@@ -44,6 +63,7 @@ tests:
           value:
             disk: ssd
             cpu: intel
+            kubernetes.io/arch: amd64
 
   - it: should set nodeSelector to non-existing on DaemonSet with stopAll
     set:

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -1,0 +1,133 @@
+suite: pod topologySpreadConstraints test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should pass with empty topologySpreadConstraints
+    set:
+      podOptions:
+        topologySpreadConstraints: {}
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: CronJob
+          schedule: "*/1 * * * *"
+          podSpec: {}
+    asserts:
+      - documentIndex: &cronJobDoc 0
+        isKind:
+          of: CronJob
+      - documentIndex: *cronJobDoc
+        isNull:
+          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+
+  - it: should pass defaults with empty topologySpreadConstraints on Deployment
+    set:
+      podOptions:
+        topologySpreadConstraints: {}
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+    asserts:
+      - documentIndex: *cronJobDoc
+        equal:
+          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+              topologyKey: "truecharts.org/rack"
+              labelSelector:
+                matchLabels:
+                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+            - maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+
+  - it: should pass with topologySpreadConstraints from "global"
+    set:
+      podOptions:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            whenUnsatisfiable: ScheduleAnyway
+            topologyKey: "truecharts.org/test"
+            labelSelector:
+              matchLabels:
+                {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+            nodeAffinityPolicy: Honor
+            nodeTaintsPolicy: Honor
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: CronJob
+          schedule: "*/1 * * * *"
+          podSpec: {}
+    asserts:
+      - documentIndex: *cronJobDoc
+        equal:
+          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+              topologyKey: "truecharts.org/test"
+              labelSelector:
+                matchLabels:
+                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+
+
+  - it: should pass with topologySpreadConstraints from "pod"
+    set:
+      podOptions:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            whenUnsatisfiable: ScheduleAnyway
+            topologyKey: "truecharts.org/test1"
+            labelSelector:
+              matchLabels:
+                {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+            nodeAffinityPolicy: Honor
+            nodeTaintsPolicy: Honor
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: CronJob
+          schedule: "*/1 * * * *"
+          podSpec:
+            topologySpreadConstraints:
+              - maxSkew: 1
+                whenUnsatisfiable: ScheduleAnyway
+                topologyKey: "truecharts.org/test2"
+                labelSelector:
+                  matchLabels:
+                    {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                nodeAffinityPolicy: Honor
+                nodeTaintsPolicy: Honor
+    asserts:
+      - documentIndex: *cronJobDoc
+        equal:
+          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+              topologyKey: "truecharts.org/test2"
+              labelSelector:
+                matchLabels:
+                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -13,16 +13,15 @@ tests:
         workload-name1:
           enabled: true
           primary: true
-          type: CronJob
-          schedule: "*/1 * * * *"
+          type: Deployment
           podSpec: {}
     asserts:
-      - documentIndex: &cronJobDoc 0
+      - documentIndex: &deploymentDoc 0
         isKind:
           of: CronJob
-      - documentIndex: *cronJobDoc
+      - documentIndex: *deploymentDoc
         isNull:
-          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          path: spec.topologySpreadConstraints
 
   - it: should pass defaults with empty topologySpreadConstraints on Deployment
     set:
@@ -35,9 +34,9 @@ tests:
           type: Deployment
           podSpec: {}
     asserts:
-      - documentIndex: *cronJobDoc
+      - documentIndex: *deploymentDoc
         equal:
-          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          path: spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
@@ -69,13 +68,12 @@ tests:
         workload-name1:
           enabled: true
           primary: true
-          type: CronJob
-          schedule: "*/1 * * * *"
+          type: Deployment
           podSpec: {}
     asserts:
-      - documentIndex: *cronJobDoc
+      - documentIndex: *deploymentDoc
         equal:
-          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          path: spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
@@ -101,8 +99,7 @@ tests:
         workload-name1:
           enabled: true
           primary: true
-          type: CronJob
-          schedule: "*/1 * * * *"
+          type: Deployment
           podSpec:
             topologySpreadConstraints:
               - maxSkew: 1
@@ -113,9 +110,9 @@ tests:
                 nodeAffinityPolicy: Honor
                 nodeTaintsPolicy: Honor
     asserts:
-      - documentIndex: *cronJobDoc
+      - documentIndex: *deploymentDoc
         equal:
-          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints
+          path: spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -8,7 +8,7 @@ tests:
   - it: should pass with empty topologySpreadConstraints
     set:
       podOptions:
-        topologySpreadConstraints: {}
+        topologySpreadConstraints: []
       workload:
         workload-name1:
           enabled: true
@@ -26,7 +26,7 @@ tests:
   - it: should pass defaults with empty topologySpreadConstraints on Deployment
     set:
       podOptions:
-        topologySpreadConstraints: {}
+        topologySpreadConstraints: []
       workload:
         workload-name1:
           enabled: true
@@ -45,14 +45,20 @@ tests:
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "truecharts.org/rack"
               labelSelector:
-                matchLabels: {}
+                matchLabels:
+                  pod.name: release-name-common-test
+                  app.kubernetes.io/name: common-test
+                  app.kubernetes.io/instance: release-name
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels: {}
+                matchLabels:
+                  pod.name: release-name-common-test
+                  app.kubernetes.io/name: common-test
+                  app.kubernetes.io/instance: release-name
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
 

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -34,6 +34,9 @@ tests:
           type: Deployment
           podSpec: {}
     asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
       - documentIndex: *deploymentDoc
         equal:
           path: spec.template.spec.topologySpreadConstraints

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -13,15 +13,15 @@ tests:
         workload-name1:
           enabled: true
           primary: true
-          type: Deployment
+          type: DaemonSet
           podSpec: {}
     asserts:
-      - documentIndex: &deploymentDoc 0
+      - documentIndex: &daemonSetDoc 0
         isKind:
-          of: CronJob
-      - documentIndex: *deploymentDoc
+          of: Deployment
+      - documentIndex: *daemonSetDoc
         isNull:
-          path: spec.topologySpreadConstraints
+          path: spec.template.spec.topologySpreadConstraints
 
   - it: should pass defaults with empty topologySpreadConstraints on Deployment
     set:
@@ -36,7 +36,7 @@ tests:
     asserts:
       - documentIndex: *deploymentDoc
         equal:
-          path: spec.topologySpreadConstraints
+          path: spec.template.spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
@@ -73,7 +73,7 @@ tests:
     asserts:
       - documentIndex: *deploymentDoc
         equal:
-          path: spec.topologySpreadConstraints
+          path: spec.template.spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
@@ -112,7 +112,7 @@ tests:
     asserts:
       - documentIndex: *deploymentDoc
         equal:
-          path: spec.topologySpreadConstraints
+          path: spec.template.spec.topologySpreadConstraints
           value:
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - documentIndex: &daemonSetDoc 0
         isKind:
-          of: Deployment
+          of: DaemonSet
       - documentIndex: *daemonSetDoc
         isNull:
           path: spec.template.spec.topologySpreadConstraints
@@ -41,26 +41,26 @@ tests:
         equal:
           path: spec.template.spec.topologySpreadConstraints
           value:
-            - maxSkew: 1
-              whenUnsatisfiable: ScheduleAnyway
-              topologyKey: "truecharts.org/rack"
-              labelSelector:
+            - labelSelector:
                 matchLabels:
-                  pod.name: release-name-common-test
+                  app.kubernetes.io/instance: test-release-name
                   app.kubernetes.io/name: common-test
-                  app.kubernetes.io/instance: release-name
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
-            - maxSkew: 1
+              topologyKey: truecharts.org/rack
               whenUnsatisfiable: ScheduleAnyway
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
+            - labelSelector:
                 matchLabels:
-                  pod.name: release-name-common-test
+                  app.kubernetes.io/instance: test-release-name
                   app.kubernetes.io/name: common-test
-                  app.kubernetes.io/instance: release-name
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
 
   - it: should pass with topologySpreadConstraints from "global"
     set:
@@ -84,13 +84,33 @@ tests:
         equal:
           path: spec.template.spec.topologySpreadConstraints
           value:
-            - maxSkew: 1
-              whenUnsatisfiable: ScheduleAnyway
-              topologyKey: "truecharts.org/test"
-              labelSelector:
-                matchLabels: {}
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: test-release-name
+                  app.kubernetes.io/name: common-test
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
+              topologyKey: truecharts.org/rack
+              whenUnsatisfiable: ScheduleAnyway
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: test-release-name
+                  app.kubernetes.io/name: common-test
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+            - labelSelector:
+                matchLabels: {}
+              maxSkew: 1
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+              topologyKey: truecharts.org/test
+              whenUnsatisfiable: ScheduleAnyway
 
 
   - it: should pass with topologySpreadConstraints from "pod"
@@ -123,10 +143,30 @@ tests:
         equal:
           path: spec.template.spec.topologySpreadConstraints
           value:
-            - maxSkew: 1
-              whenUnsatisfiable: ScheduleAnyway
-              topologyKey: "truecharts.org/test2"
-              labelSelector:
-                matchLabels: {}
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: test-release-name
+                  app.kubernetes.io/name: common-test
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
+              topologyKey: truecharts.org/rack
+              whenUnsatisfiable: ScheduleAnyway
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: test-release-name
+                  app.kubernetes.io/name: common-test
+                  pod.name: test-release-name-common-test
+              maxSkew: 1
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+            - labelSelector:
+                matchLabels: {}
+              maxSkew: 1
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+              topologyKey: truecharts.org/test2
+              whenUnsatisfiable: ScheduleAnyway

--- a/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -43,16 +43,14 @@ tests:
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "truecharts.org/rack"
               labelSelector:
-                matchLabels:
-                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                matchLabels: {}
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
             - maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels:
-                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                matchLabels: {}
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
 
@@ -64,8 +62,7 @@ tests:
             whenUnsatisfiable: ScheduleAnyway
             topologyKey: "truecharts.org/test"
             labelSelector:
-              matchLabels:
-                {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              matchLabels: {}
             nodeAffinityPolicy: Honor
             nodeTaintsPolicy: Honor
       workload:
@@ -84,8 +81,7 @@ tests:
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "truecharts.org/test"
               labelSelector:
-                matchLabels:
-                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                matchLabels: {}
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor
 
@@ -98,8 +94,7 @@ tests:
             whenUnsatisfiable: ScheduleAnyway
             topologyKey: "truecharts.org/test1"
             labelSelector:
-              matchLabels:
-                {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+              matchLabels: {}
             nodeAffinityPolicy: Honor
             nodeTaintsPolicy: Honor
       workload:
@@ -114,8 +109,7 @@ tests:
                 whenUnsatisfiable: ScheduleAnyway
                 topologyKey: "truecharts.org/test2"
                 labelSelector:
-                  matchLabels:
-                    {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                  matchLabels: {}
                 nodeAffinityPolicy: Honor
                 nodeTaintsPolicy: Honor
     asserts:
@@ -127,7 +121,6 @@ tests:
               whenUnsatisfiable: ScheduleAnyway
               topologyKey: "truecharts.org/test2"
               labelSelector:
-                matchLabels:
-                  {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+                matchLabels: {}
               nodeAffinityPolicy: Honor
               nodeTaintsPolicy: Honor

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.2.3
+version: 14.2.4

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.2.4
+version: 14.3.0

--- a/library/common/templates/lib/pod/_nodeSelector.tpl
+++ b/library/common/templates/lib/pod/_nodeSelector.tpl
@@ -20,20 +20,14 @@ objectData: The object data to be used to render the Pod.
     {{- $selectors = . -}}
   {{- end -}}
 
-  {{- if $selectors.kubernetes.io/arch -}}
-    {{- if eq  $selectors.kubernetes.io/arch "" -}}
-      {{- $_ := unset $selectors "kubernetes.io/arch" -}}
-    {{- end -}}
-  {{- end -}}
-
   {{- if and (include "tc.v1.common.lib.util.stopAll" $rootCtx) (eq $objectData.type "DaemonSet") }}
 "non-existing": "true"
   {{ else }}
     {{- range $k, $v := $selectors -}}
       {{- if not $v -}}
-        {{- fail (printf "Expected non-empty value on <nodeSelector> [%s] key." $k) -}}
-      {{- end }}
+      {{- else }}
 {{ $k }}: {{ tpl $v $rootCtx }}
+      {{- end -}}
     {{- end -}}
   {{ end }}
 {{- end -}}

--- a/library/common/templates/lib/pod/_nodeSelector.tpl
+++ b/library/common/templates/lib/pod/_nodeSelector.tpl
@@ -20,6 +20,12 @@ objectData: The object data to be used to render the Pod.
     {{- $selectors = . -}}
   {{- end -}}
 
+  {{- if $selectors.kubernetes.io/arch -}}
+    {{- if eq  $selectors.kubernetes.io/arch "" -}}
+      {{- $_ := unset $selectors "kubernetes.io/arch" -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- if and (include "tc.v1.common.lib.util.stopAll" $rootCtx) (eq $objectData.type "DaemonSet") }}
 "non-existing": "true"
   {{ else }}

--- a/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
+++ b/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
@@ -21,24 +21,24 @@ objectData: The object data to be used to render the Pod.
   {{- end -}}
 
   {{- if and ( or ( eq $objectData.type "Deployment" ) ( eq $objectData.type "StatefulSet" )) $rootCtx.Values.podOptions.defaultSpread }}
-    - maxSkew: 1
-      whenUnsatisfiable: ScheduleAnyway
-      topologyKey: "truecharts.org/rack"
-      labelSelector:
-        matchLabels:
-          {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
-      nodeAffinityPolicy: Honor
-      nodeTaintsPolicy: Honor
-    - maxSkew: 1
-      whenUnsatisfiable: ScheduleAnyway
-      topologyKey: "kubernetes.io/hostname"
-      labelSelector:
-        matchLabels:
-          {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
-      nodeAffinityPolicy: Honor
-      nodeTaintsPolicy: Honor
+- maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
+  topologyKey: "truecharts.org/rack"
+  labelSelector:
+    matchLabels:
+      {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+  nodeAffinityPolicy: Honor
+  nodeTaintsPolicy: Honor
+- maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
+  topologyKey: "kubernetes.io/hostname"
+  labelSelector:
+    matchLabels:
+      {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+  nodeAffinityPolicy: Honor
+  nodeTaintsPolicy: Honor
   {{ end }}
-    {{- range $v := $constraints -}}
+  {{- range $v := $constraints -}}
 - {{ tpl $v $rootCtx }}
-    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
+++ b/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
@@ -20,7 +20,7 @@ objectData: The object data to be used to render the Pod.
     {{- $constraints = . -}}
   {{- end -}}
 
-  {{- if and ( or ( eq $objectData.type "Deployment" ) ( eq $objectData.type "StatefulSet" )) $rootCtx.Values.podOptions.defaultSpread }}
+  {{- if and ( or ( eq $objectData.type "Deployment" ) ( eq $objectData.type "StatefulSet" )) $rootCtx.Values.podOptions.defaultSpread -}}
 - maxSkew: 1
   whenUnsatisfiable: ScheduleAnyway
   topologyKey: "truecharts.org/rack"
@@ -37,8 +37,8 @@ objectData: The object data to be used to render the Pod.
       {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
   nodeAffinityPolicy: Honor
   nodeTaintsPolicy: Honor
-  {{ end }}
-  {{- range $v := $constraints -}}
-- {{ $v }}
   {{- end -}}
+  {{ with $constraints }}
+{{ . | toYaml | indent 0 }}
+  {{ end }}
 {{- end -}}

--- a/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
+++ b/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
@@ -39,6 +39,6 @@ objectData: The object data to be used to render the Pod.
   nodeTaintsPolicy: Honor
   {{ end }}
   {{- range $v := $constraints -}}
-- {{ tpl $v $rootCtx }}
+- {{ $v }}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
+++ b/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
@@ -1,0 +1,44 @@
+{{/* Returns topologySpreadConstraints  */}}
+{{/* Call this template:
+{{ include "tc.v1.common.lib.pod.topologySpreadConstraints" (dict "rootCtx" $ "objectData" $objectData) }}
+rootCtx: The root context of the chart.
+objectData: The object data to be used to render the Pod.
+*/}}
+{{- define "tc.v1.common.lib.pod.topologySpreadConstraints" -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData -}}
+
+  {{- $constraints := list -}}
+
+  {{/* Initialize from the "global" option */}}
+  {{- with $rootCtx.Values.podOptions.topologySpreadConstraints -}}
+    {{- $constraints = . -}}
+  {{- end -}}
+
+  {{/* Override with pods option */}}
+  {{- with $objectData.podSpec.topologySpreadConstraints -}}
+    {{- $constraints = . -}}
+  {{- end -}}
+
+  {{- if and ( or ( eq $objectData.type "Deployment" ) ( eq $objectData.type "StatefulSet" )) $rootCtx.Values.podOptions.defaultSpread }}
+    - maxSkew: 1
+      whenUnsatisfiable: ScheduleAnyway
+      topologyKey: "truecharts.org/rack"
+      labelSelector:
+        matchLabels:
+          {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+      nodeAffinityPolicy: Honor
+      nodeTaintsPolicy: Honor
+    - maxSkew: 1
+      whenUnsatisfiable: ScheduleAnyway
+      topologyKey: "kubernetes.io/hostname"
+      labelSelector:
+        matchLabels:
+          {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.name) | indent 6 }}
+      nodeAffinityPolicy: Honor
+      nodeTaintsPolicy: Honor
+  {{ end }}
+    {{- range $v := $constraints -}}
+- {{ tpl $v $rootCtx }}
+    {{- end -}}
+{{- end -}}

--- a/library/common/templates/lib/workload/_pod.tpl
+++ b/library/common/templates/lib/workload/_pod.tpl
@@ -29,6 +29,10 @@ priorityClassName: {{ . }}
 nodeSelector:
     {{- . | nindent 2 }}
   {{- end -}}
+  {{- with (include "tc.v1.common.lib.pod.topologySpreadConstraints" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim) }}
+topologySpreadConstraints:
+    {{- . | nindent 2 }}
+  {{- end -}}
   {{- with (include "tc.v1.common.lib.pod.hostAliases" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim) }}
 hostAliases:
     {{- . | nindent 2 }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -140,6 +140,9 @@ podOptions:
   hostAliases: []
   nodeSelector:
     kubernetes.io/arch: "amd64"
+  # -- Used to enforce a good spread for Deployments and StatefulSets by default
+  defaultSpread: true
+  topologySpreadConstraints: []
   tolerations: []
   schedulerName: ""
   priorityClassName: ""

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -138,7 +138,8 @@ podOptions:
       - name: ndots
         value: "1"
   hostAliases: []
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: "amd64"
   tolerations: []
   schedulerName: ""
   priorityClassName: ""


### PR DESCRIPTION
**Description**
When moving to support clustered and multi-arch systems, we need to ensure our charts are only ran on AMD64 by default, as not all containers support ARM64 (or example).

Further more, we need to ensure our pods can have their topologySpreadConstraints set.

As replica's of the same deployment, should not be put on the same nodes and, preferably, spread accross multiple racks (failure domains), we need to setup sane defaults to push the kubernetes scheduler to try to put replica's on seperate nodes and failure domains by default for Deployments and StatefulSets.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
Also removes the failure on empty nodeSelector and instead skips empty nodeSelectors, this allows for explicit overrides.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
