### PR TITLE
fix(common): fix primary cert warning on older helm versions

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.3.0
+version: 14.3.1

--- a/library/common/templates/lib/util/_primary_certificate.tpl
+++ b/library/common/templates/lib/util/_primary_certificate.tpl
@@ -1,0 +1,23 @@
+{{/* Return the name of the primary Cert object */}}
+{{- define "tc.v1.common.lib.util.cert.primary" -}}
+  {{- $Certs := $.Values.cert -}}
+
+  {{- $enabledCerts := dict -}}
+  {{- range $name, $cert := $Certs -}}
+    {{- if $cert.enabled -}}
+      {{- $_ := set $enabledCerts $name . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $result := "" -}}
+  {{- range $name, $cert := $enabledCerts -}}
+    {{- if and (hasKey $cert "primary") $cert.primary -}}
+      {{- $result = $name -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if not $result -}}
+    {{- $result = keys $Certs | first -}}
+  {{- end -}}
+  {{- $result -}}
+{{- end -}}


### PR DESCRIPTION
**Description**
Older helm versions, such as TrueNAS SCALE Bluefin, throw an error due to missing primary cert util object.
This adds said object

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
