### PR TITLE
feat(common): add priorityClass class and spawner

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~14.4.0
+  version: ~14.5.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/ci/priorityclass-values.yaml
+++ b/library/common-test/ci/priorityclass-values.yaml
@@ -1,0 +1,50 @@
+service:
+  main:
+    enabled: true
+    primary: true
+    ports:
+      main:
+        enabled: true
+        primary: true
+        protocol: http
+        port: 8080
+
+workload:
+  main:
+    enabled: true
+    primary: true
+    type: Deployment
+    podSpec:
+      containers:
+        main:
+          enabled: true
+          primary: true
+          args:
+            - --port
+            - "8080"
+          probes:
+            liveness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            readiness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            startup:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+
+# -- create storageClasses on demand
+priorityClass:
+  example:
+    provisioner: some.provisioner.io
+    enabled: true
+    value: 1000000
+    preemptionPolicy: PreemptLowerPriority
+    globalDefault: false
+    description: "some description"
+
+manifestManager:
+  enabled: false

--- a/library/common-test/tests/pod/priority_class_name_test.yaml
+++ b/library/common-test/tests/pod/priority_class_name_test.yaml
@@ -58,7 +58,7 @@ tests:
 
   - it: should pass with priorityClassName from "pod" with tpl
     set:
-      priorityClass: some-other-priority-class
+      priorityClassTest: some-other-priority-class
       podOptions:
         priorityClassName: some-priority-class
       workload:
@@ -67,7 +67,7 @@ tests:
           primary: true
           type: Deployment
           podSpec:
-            priorityClassName: "{{ .Values.priorityClass }}"
+            priorityClassName: "{{ .Values.priorityClassTest }}"
     asserts:
       - documentIndex: *deploymentDoc
         equal:

--- a/library/common-test/tests/priorityClass/metadata_test.yaml
+++ b/library/common-test/tests/priorityClass/metadata_test.yaml
@@ -1,0 +1,59 @@
+suite: priorityClass metadata test
+templates:
+  - common.yaml
+chart:
+  appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should pass with priorityClass created with labels and annotations
+    set:
+      label1: label1
+      label2: global_label2
+      annotation1: annotation1
+      annotation2: global_annotation2
+      global:
+        labels:
+          g_label1: global_label1
+          g_label2: "{{ .Values.label2 }}"
+        annotations:
+          g_annotation1: global_annotation1
+          g_annotation2: "{{ .Values.annotation2 }}"
+      priorityClass:
+        example1:
+          enabled: true
+          labels:
+            label1: "{{ .Values.label1 }}"
+            label2: label2
+          annotations:
+            annotation1: "{{ .Values.annotation1 }}"
+            annotation2: annotation2
+    asserts:
+      - documentIndex: &storageClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *storageClassDoc
+        equal:
+          path: metadata.annotations
+          value:
+            annotation1: annotation1
+            annotation2: annotation2
+            g_annotation1: global_annotation1
+            g_annotation2: global_annotation2
+      - documentIndex: *storageClassDoc
+        equal:
+          path: metadata.labels
+          value:
+            app: common-test-1.0.0
+            release: test-release-name
+            helm-revision: "0"
+            helm.sh/chart: common-test-1.0.0
+            app.kubernetes.io/name: common-test
+            app.kubernetes.io/instance: test-release-name
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/version: *appVer
+            g_label1: global_label1
+            g_label2: global_label2
+            label1: label1
+            label2: label2

--- a/library/common-test/tests/priorityClass/names_test.yaml
+++ b/library/common-test/tests/priorityClass/names_test.yaml
@@ -1,0 +1,35 @@
+suite: priorityClass name test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should generate correct name
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+        example2:
+          enabled: true
+    asserts:
+      - documentIndex: &storageClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *storageClassDoc
+        isAPIVersion:
+          of: scheduling.k8s.io/v1
+      - documentIndex: *storageClassDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-example1
+      - documentIndex: &otherStorageClassDoc 1
+        isKind:
+          of: PriorityClass
+      - documentIndex: *otherStorageClassDoc
+        isAPIVersion:
+          of: scheduling.k8s.io/v1
+      - documentIndex: *otherStorageClassDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-example2

--- a/library/common-test/tests/priorityClass/spec_test.yaml
+++ b/library/common-test/tests/priorityClass/spec_test.yaml
@@ -1,0 +1,107 @@
+suite: priorityClass name test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should generate correct spec
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+    asserts:
+      - documentIndex: &priorityClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *priorityClassDoc
+        isAPIVersion:
+          of: scheduling.k8s.io/v1
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: value
+          value: 1000000
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: preemptionPolicy
+          value: PreemptLowerPriority
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: globalDefault
+          value: false
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: description
+          value: No description given
+
+  - it: should generate correct spec with non-default value
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+          value: 1000
+    asserts:
+      - documentIndex: &priorityClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: value
+          value: 1000
+
+  - it: should generate correct spec with non-default preemptionPolicy
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+          preemptionPolicy: Never
+    asserts:
+      - documentIndex: &priorityClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: preemptionPolicy
+          value: Never
+
+  - it: should generate correct spec with non-default globalDefault
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+          globalDefault: true
+    asserts:
+      - documentIndex: &priorityClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: globalDefault
+          value: true
+
+  - it: should generate correct spec with non-default description
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+          description: test description
+    asserts:
+      - documentIndex: &priorityClassDoc 0
+        isKind:
+          of: PriorityClass
+      - documentIndex: *priorityClassDoc
+        equal:
+          path: description
+          value: test description
+
+#   - it:
+# Failures
+  - it: should fail with invalid preemptionPolicy
+    set:
+      priorityClass:
+        example1:
+          enabled: true
+          preemptionPolicy: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: Priority Class - Expected [preemptionPolicy] to be one of [PreemptLowerPriority, Never], but got [invalid]

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 14.4.0
+version: 14.5.0

--- a/library/common/templates/class/_priorityClass.tpl
+++ b/library/common/templates/class/_priorityClass.tpl
@@ -1,0 +1,36 @@
+{{/* priorityclass Class */}}
+{{/* Call this template:
+{{ include "tc.v1.common.class.priorityclass" (dict "rootCtx" $ "objectData" $objectData) }}
+
+rootCtx: The root context of the chart.
+objectData:
+  name: The name of the priorityclass.
+  labels: The labels of the priorityclass.
+  annotations: The annotations of the priorityclass.
+*/}}
+
+{{- define "tc.v1.common.class.priorityclass" -}}
+
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $objectData.name }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "priorityclass") }}
+  {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
+  labels:
+    {{- . | nindent 4 }}
+  {{- end -}}
+  {{- $annotations := (mustMerge ($objectData.annotations | default dict) (include "tc.v1.common.lib.metadata.allAnnotations" $rootCtx | fromYaml)) -}}
+  {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "annotations" $annotations) | trim) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+value: {{ $objectData.value | default 1000000 }}
+preemptionPolicy: Never{{ $objectData.preemptionPolicy | default "PreemptLowerPriority" }}
+globalDefault: {{ $objectData.globalDefault | default false }}
+description: {{ $objectData.description | default "No description given"}}
+{{- end -}}

--- a/library/common/templates/class/_priorityClass.tpl
+++ b/library/common/templates/class/_priorityClass.tpl
@@ -12,7 +12,11 @@ objectData:
 {{- define "tc.v1.common.class.priorityclass" -}}
 
   {{- $rootCtx := .rootCtx -}}
-  {{- $objectData := .objectData }}
+  {{- $objectData := .objectData -}}
+  {{- $globalDefault := false -}}
+  {{- if not (kindIs "invalid" $objectData.globalDefault) -}}
+    {{- $globalDefault = $objectData.globalDefault -}}
+  {{- end }}
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -30,7 +34,7 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 value: {{ $objectData.value | default 1000000 }}
-preemptionPolicy: Never{{ $objectData.preemptionPolicy | default "PreemptLowerPriority" }}
-globalDefault: {{ $objectData.globalDefault | default false }}
-description: {{ $objectData.description | default "No description given"}}
+preemptionPolicy: {{ $objectData.preemptionPolicy | default "PreemptLowerPriority" }}
+globalDefault: {{ $globalDefault }}
+description: {{ $objectData.description | default "No description given" }}
 {{- end -}}

--- a/library/common/templates/lib/priorityClass/_validation.tpl
+++ b/library/common/templates/lib/priorityClass/_validation.tpl
@@ -1,0 +1,11 @@
+{{- define "tc.v1.common.lib.priorityclass.validation" -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData -}}
+
+  {{- $validPolicies := (list "PreemptLowerPriority" "Never") -}}
+  {{- if $objectData.preemptionPolicy -}}
+    {{- if not (mustHas $objectData.preemptionPolicy $validPolicies) -}}
+      {{- fail (printf "Priority Class - Expected [preemptionPolicy] to be one of [%s], but got [%s]" (join ", " $validPolicies) $objectData.preemptionPolicy) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/library/common/templates/loader/_apply.tpl
+++ b/library/common/templates/loader/_apply.tpl
@@ -13,6 +13,9 @@
   {{/* Render ConfigMap(s) */}}
   {{- include "tc.v1.common.spawner.configmap" . | nindent 0 -}}
 
+  {{/* Render priorityclass(s) */}}
+  {{- include "tc.v1.common.spawner.priorityclass" . | nindent 0 -}}
+
   {{/* Render Certificate(s) */}}
   {{- include "tc.v1.common.spawner.scaleCertificate" . | nindent 0 -}}
 

--- a/library/common/templates/spawner/_priorityClass.tpl
+++ b/library/common/templates/spawner/_priorityClass.tpl
@@ -1,0 +1,59 @@
+{{/* priorityclass Spawwner */}}
+{{/* Call this template:
+{{ include "tc.v1.common.spawner.priorityclass" $ -}}
+*/}}
+
+{{- define "tc.v1.common.spawner.priorityclass" -}}
+  {{- $fullname := include "tc.v1.common.lib.chart.names.fullname" $ -}}
+
+  {{- range $name, $priorityclass := .Values.priorityclass -}}
+
+    {{- $enabled := false -}}
+    {{- if hasKey $priorityclass "enabled" -}}
+      {{- if not (kindIs "invalid" $priorityclass.enabled) -}}
+        {{- $enabled = $priorityclass.enabled -}}
+      {{- else -}}
+        {{- fail (printf "priorityclass - Expected the defined key [enabled] in <priorityclass.%s> to not be empty" $name) -}}
+      {{- end -}}
+    {{- end -}}
+
+
+    {{- if kindIs "string" $enabled -}}
+      {{- $enabled = tpl $enabled $ -}}
+
+      {{/* After tpl it becomes a string, not a bool */}}
+      {{-  if eq $enabled "true" -}}
+        {{- $enabled = true -}}
+      {{- else if eq $enabled "false" -}}
+        {{- $enabled = false -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- if $enabled -}}
+
+      {{/* Create a copy of the priorityclass */}}
+      {{- $objectData := (mustDeepCopy $priorityclass) -}}
+
+      {{- $objectName := (printf "%s-%s" $fullname $name) -}}
+      {{- if hasKey $objectData "expandObjectName" -}}
+        {{- if not $objectData.expandObjectName -}}
+          {{- $objectName = $name -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{/* Perform validations */}} {{/* priorityclasss have a max name length of 253 */}}
+      {{- include "tc.v1.common.lib.chart.names.validation" (dict "name" $objectName "length" 253) -}}
+      {{- include "tc.v1.common.lib.metadata.validation" (dict "objectData" $objectData "caller" "priorityclass") -}}
+
+      {{/* Set the name of the priorityclass */}}
+      {{- $_ := set $objectData "name" $objectName -}}
+      {{- $_ := set $objectData "shortName" $name -}}
+
+      {{/* Call class to create the object */}}
+      {{- include "tc.v1.common.class.priorityclass" (dict "rootCtx" $ "objectData" $objectData) -}}
+
+    {{- end -}}
+
+  {{- end -}}
+
+{{- end -}}

--- a/library/common/templates/spawner/_priorityClass.tpl
+++ b/library/common/templates/spawner/_priorityClass.tpl
@@ -6,14 +6,14 @@
 {{- define "tc.v1.common.spawner.priorityclass" -}}
   {{- $fullname := include "tc.v1.common.lib.chart.names.fullname" $ -}}
 
-  {{- range $name, $priorityclass := .Values.priorityclass -}}
+  {{- range $name, $priorityclass := .Values.priorityClass -}}
 
     {{- $enabled := false -}}
     {{- if hasKey $priorityclass "enabled" -}}
       {{- if not (kindIs "invalid" $priorityclass.enabled) -}}
         {{- $enabled = $priorityclass.enabled -}}
       {{- else -}}
-        {{- fail (printf "priorityclass - Expected the defined key [enabled] in <priorityclass.%s> to not be empty" $name) -}}
+        {{- fail (printf "Priority Class - Expected the defined key [enabled] in <priorityclass.%s> to not be empty" $name) -}}
       {{- end -}}
     {{- end -}}
 
@@ -49,6 +49,8 @@
       {{- $_ := set $objectData "name" $objectName -}}
       {{- $_ := set $objectData "shortName" $name -}}
 
+      {{/* Validate */}}
+      {{- include "tc.v1.common.lib.priorityclass.validation" (dict "rootCtx" $ "objectData" $objectData) -}}
       {{/* Call class to create the object */}}
       {{- include "tc.v1.common.class.priorityclass" (dict "rootCtx" $ "objectData" $objectData) -}}
 

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -561,6 +561,16 @@ webhook:
     type: mutating
     webhooks: []
 
+# # -- create storageClasses on demand
+# priorityClass:
+#   example:
+#     provisioner: some.provisioner.io
+#     enabled: true
+#     value: 1000000
+#     preemptionPolicy: PreemptLowerPriority
+#     globalDefault: false
+#     description: "some description"
+
 metrics:
   main:
     enabled: false


### PR DESCRIPTION
**Description**

This adds the ability to spawn priorityClass objects using common.
In the future we might want to use this to set some standardised priorityClasses to correct/improve scheduling of our charts

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
