### PR TITLE
feat(common): add support for iscsi volumes

### DIFF
--- a/library/common-test/tests/persistence/validation_test.yaml
+++ b/library/common-test/tests/persistence/validation_test.yaml
@@ -43,7 +43,7 @@ tests:
           type: not-a-type
     asserts:
       - failedTemplate:
-          errorMessage: Persistence - Expected [type] to be one of [pvc, vct, emptyDir, nfs, hostPath, ixVolume, secret, configmap, device], but got [not-a-type]
+          errorMessage: Persistence - Expected [type] to be one of [pvc, vct, emptyDir, nfs, iscsi, hostPath, ixVolume, secret, configmap, device], but got [not-a-type]
 
   - it: should fail with invalid accessMode
     set:

--- a/library/common-test/tests/pod/volume_iscsi_test.yaml
+++ b/library/common-test/tests/pod/volume_iscsi_test.yaml
@@ -40,6 +40,8 @@ tests:
               iqn: some-iqn
               lun: 0
               fsType: ext4
+              chapAuthDiscovery: false
+              chapAuthSession: false
 
   - it: should pass with iscsi volume with extra options
     set:
@@ -91,6 +93,102 @@ tests:
               portals:
                 - some-targetPortal
                 - some-targetPortal2
+              chapAuthDiscovery: false
+              chapAuthSession: false
+
+  - it: should pass with iscsi volume with chap auth
+    set:
+      username: some-username
+      password: some-password
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        iscsi-vol:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: ext4
+            targetPortal: some-targetPortal
+            iqn: some-iqn
+            lun: 0
+            authSession:
+              username: some-username
+              password: some-password
+              usernameInitiator: some-usernameInitiator
+              passwordInitiator: some-passwordInitiator
+        iscsi-vol2:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: ext4
+            targetPortal: some-targetPortal
+            iqn: some-iqn
+            lun: 0
+            discoverySession:
+              username: some-username
+              password: some-password
+              usernameInitiator: some-usernameInitiator
+              passwordInitiator: some-passwordInitiator
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: iscsi-vol
+            iscsi:
+              targetPortal: some-targetPortal
+              iqn: some-iqn
+              lun: 0
+              fsType: ext4
+              chapAuthDiscovery: false
+              chapAuthSession: true
+              secretRef:
+                name: test-release-name-common-test-iscsi-vol
+      - documentIndex: &secretDoc 1
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          content: test-release-name-common-test-iscsi-vol
+      - documentIndex: *secretDoc
+        equal:
+          path: type
+          content: kubernetes.io/iscsi-chap
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            node.session.auth.username: "{{ .Values.username }}"
+            node.session.auth.password: "{{ .Values.password }}"
+            node.session.auth.username_in: '{{ printf "%s%s".Values.username "Initiator" }}'
+            node.session.auth.password_in: '{{ printf "%s%s".Values.password "Initiator" }}'
+      - documentIndex: &secretDoc 2
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          content: test-release-name-common-test-iscsi-vol2
+      - documentIndex: *secretDoc
+        equal:
+          path: type
+          content: kubernetes.io/iscsi-chap
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            discovery.sendtargets.auth.username: "{{ .Values.username }}"
+            discovery.sendtargets.auth.password: "{{ .Values.password }}"
+            discovery.sendtargets.auth.username_in: '{{ printf "%s%s".Values.username "Initiator" }}'
+            discovery.sendtargets.auth.password_in: '{{ printf "%s%s".Values.password "Initiator" }}'
 
 # Failures
   - it: should fail without iscsi object in iscsi volume

--- a/library/common-test/tests/pod/volume_iscsi_test.yaml
+++ b/library/common-test/tests/pod/volume_iscsi_test.yaml
@@ -1,0 +1,185 @@
+suite: pod iscsi volume test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should pass with iscsi volume
+    set:
+      some_lun: 0
+      some_iqn: some-iqn
+      some_targetPortal: some-targetPortal
+      some_fsType: ext4
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        iscsi-vol:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: "{{ .Values.some_fsType }}"
+            targetPortal: "{{ .Values.some_targetPortal }}"
+            iqn: "{{ .Values.some_iqn }}"
+            lun: "{{ .Values.some_lun }}"
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: iscsi-vol
+            iscsi:
+              targetPortal: some-targetPortal
+              iqn: some-iqn
+              lun: 0
+              fsType: ext4
+
+  - it: should pass with iscsi volume with extra options
+    set:
+      some_lun: 99999999999
+      some_iqn: some-iqn
+      some_targetPortal: some-targetPortal
+      some_fsType: ext4
+      some_initiatorName: some-initiatorName
+      some_interface: some-interface
+      some_portals:
+        - some-targetPortal
+        - some-targetPortal2
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        iscsi-vol:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: "{{ .Values.some_fsType }}"
+            targetPortal: "{{ .Values.some_targetPortal }}"
+            iqn: "{{ .Values.some_iqn }}"
+            lun: "{{ .Values.some_lun }}"
+            initiatorName: "{{ .Values.some_initiatorName }}"
+            iscsiInterface: "{{ .Values.some_interface }}"
+            portals:
+              - "{{ index .Values.some_portals 0 }}"
+              - "{{ index .Values.some_portals 1 }}"
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: iscsi-vol
+            iscsi:
+              targetPortal: some-targetPortal
+              iqn: some-iqn
+              lun: 99999999999
+              fsType: ext4
+              initiatorName: some-initiatorName
+              iscsiInterface: some-interface
+              portals:
+                - some-targetPortal
+                - some-targetPortal2
+
+# Failures
+  - it: should fail without iscsi object in iscsi volume
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        volume1:
+          enabled: true
+          type: iscsi
+    asserts:
+      - failedTemplate:
+          errorMessage: Persistence - Expected non-empty [iscsi] object on [iscsi] type
+
+  - it: should fail with invalid fsType in iscsi
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        volume1:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: some-fsType
+    asserts:
+      - failedTemplate:
+          errorMessage: Persistence - Expected [fsType] on [iscsi] type to be one of [ext4, xfs, ntfs], but got [some-fsType]
+
+  - it: should fail without targetPortal in iscsi
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        volume1:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: ext4
+    asserts:
+      - failedTemplate:
+          errorMessage: Persistence - Expected non-empty [targetPortal] on [iscsi] type
+
+  - it: should fail without iqn in iscsi
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        volume1:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: ext4
+            targetPortal: some-targetPortal
+    asserts:
+      - failedTemplate:
+          errorMessage: Persistence - Expected non-empty [iqn] on [iscsi] type
+
+  - it: should fail without lun in iscsi
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        volume1:
+          enabled: true
+          type: iscsi
+          iscsi:
+            fsType: ext4
+            targetPortal: some-targetPortal
+            iqn: some-iqn
+    asserts:
+      - failedTemplate:
+          errorMessage: Persistence - Expected non-empty [lun] on [iscsi] type

--- a/library/common-test/tests/pod/volume_iscsi_test.yaml
+++ b/library/common-test/tests/pod/volume_iscsi_test.yaml
@@ -116,10 +116,10 @@ tests:
             iqn: some-iqn
             lun: 0
             authSession:
-              username: some-username
-              password: some-password
-              usernameInitiator: some-usernameInitiator
-              passwordInitiator: some-passwordInitiator
+              username: "{{ .Values.username }}"
+              password: "{{ .Values.password }}"
+              usernameInitiator: '{{ printf "%s%s" .Values.username "Initiator" }}'
+              passwordInitiator: '{{ printf "%s%s" .Values.password "Initiator" }}'
         iscsi-vol2:
           enabled: true
           type: iscsi
@@ -128,11 +128,11 @@ tests:
             targetPortal: some-targetPortal
             iqn: some-iqn
             lun: 0
-            discoverySession:
-              username: some-username
-              password: some-password
-              usernameInitiator: some-usernameInitiator
-              passwordInitiator: some-passwordInitiator
+            authDiscovery:
+              username: "{{ .Values.username }}"
+              password: "{{ .Values.password }}"
+              usernameInitiator: '{{ printf "%s%s" .Values.username "Initiator" }}'
+              passwordInitiator: '{{ printf "%s%s" .Values.password "Initiator" }}'
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -151,44 +151,58 @@ tests:
               chapAuthSession: true
               secretRef:
                 name: test-release-name-common-test-iscsi-vol
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: iscsi-vol2
+            iscsi:
+              targetPortal: some-targetPortal
+              iqn: some-iqn
+              lun: 0
+              fsType: ext4
+              chapAuthDiscovery: true
+              chapAuthSession: false
+              secretRef:
+                name: test-release-name-common-test-iscsi-vol2
       - documentIndex: &secretDoc 1
         isKind:
           of: Secret
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          content: test-release-name-common-test-iscsi-vol
+          value: test-release-name-common-test-iscsi-vol
       - documentIndex: *secretDoc
         equal:
           path: type
-          content: kubernetes.io/iscsi-chap
+          value: kubernetes.io/iscsi-chap
       - documentIndex: *secretDoc
         equal:
           path: stringData
           value:
-            node.session.auth.username: "{{ .Values.username }}"
-            node.session.auth.password: "{{ .Values.password }}"
-            node.session.auth.username_in: '{{ printf "%s%s".Values.username "Initiator" }}'
-            node.session.auth.password_in: '{{ printf "%s%s".Values.password "Initiator" }}'
+            node.session.auth.username: some-username
+            node.session.auth.password: some-password
+            node.session.auth.username_in: some-usernameInitiator
+            node.session.auth.password_in: some-passwordInitiator
       - documentIndex: &secretDoc 2
         isKind:
           of: Secret
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          content: test-release-name-common-test-iscsi-vol2
+          value: test-release-name-common-test-iscsi-vol2
       - documentIndex: *secretDoc
         equal:
           path: type
-          content: kubernetes.io/iscsi-chap
+          value: kubernetes.io/iscsi-chap
       - documentIndex: *secretDoc
         equal:
           path: stringData
           value:
-            discovery.sendtargets.auth.username: "{{ .Values.username }}"
-            discovery.sendtargets.auth.password: "{{ .Values.password }}"
-            discovery.sendtargets.auth.username_in: '{{ printf "%s%s".Values.username "Initiator" }}'
-            discovery.sendtargets.auth.password_in: '{{ printf "%s%s".Values.password "Initiator" }}'
+            discovery.sendtargets.auth.username: some-username
+            discovery.sendtargets.auth.password: some-password
+            discovery.sendtargets.auth.username_in: some-usernameInitiator
+            discovery.sendtargets.auth.password_in: some-passwordInitiator
 
 # Failures
   - it: should fail without iscsi object in iscsi volume

--- a/library/common/templates/lib/pod/_volumes.tpl
+++ b/library/common/templates/lib/pod/_volumes.tpl
@@ -61,6 +61,8 @@ objectData: The object data to be used to render the Pod.
           {{- include "tc.v1.common.lib.pod.volume.emptyDir" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- else if eq "nfs" $type -}}
           {{- include "tc.v1.common.lib.pod.volume.nfs" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
+        {{- else if eq "iscsi" $type -}}
+          {{- include "tc.v1.common.lib.pod.volume.iscsi" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- else if eq "device" $type -}}
           {{- include "tc.v1.common.lib.pod.volume.device" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- end -}}

--- a/library/common/templates/lib/pod/volumes/_iscsi.tpl
+++ b/library/common/templates/lib/pod/volumes/_iscsi.tpl
@@ -1,0 +1,39 @@
+{{/* Returns iscsi Volume */}}
+{{/* Call this template:
+{{ include "tc.v1.common.lib.pod.volume.iscsi" (dict "rootCtx" $ "objectData" $objectData) }}
+rootCtx: The root context of the chart.
+objectData: The object data to be used to render the volume.
+*/}}
+{{- define "tc.v1.common.lib.pod.volume.iscsi" -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData -}}
+
+  {{- if not $objectData.scsi.targetPortal -}}
+    {{- fail "Persistence - Expected non-empty [targetPortal] on [iscsi] type" -}}
+  {{- end -}}
+
+  {{- if not $objectData.scsi.iqn -}}
+    {{- fail "Persistence - Expected non-empty [iqn] on [iscsi] type" -}}
+  {{- end -}}
+
+  {{- if not $objectData.scsi.lun -}}
+    {{- fail "Persistence - Expected non-empty [lun] on [iscsi] type" -}}
+  {{- end -}}
+- name: {{ $objectData.shortName }}
+  iscsi:
+    targetPortal: {{ $objectData.scsi.targetPortal }}
+    {{- with $objectData.scsi.portals -}}
+    portals:
+    {{- tpl (toYaml .) $rootCtx | nindent 4 }}
+    {{- end -}}
+    iqn: {{ $objectData.scsi.iqn }}
+    lun: {{ $objectData.scsi.lun }}
+    {{- with $objectData.scsi.iscsiInterface -}}
+    iscsiInterface: {{ . }}
+    {{- end -}}
+    {{- with $objectData.scsi.fsType -}}
+    fsType: {{ . }}
+    {{- end -}}
+    readOnly: {{ $objectData.scsi.targetPortal | default false }}
+{{/* TODO: add chap auth support */}}
+{{- end -}}

--- a/library/common/templates/lib/pod/volumes/_iscsi.tpl
+++ b/library/common/templates/lib/pod/volumes/_iscsi.tpl
@@ -38,11 +38,11 @@ objectData: The object data to be used to render the volume.
 
   {{- $authSession := false -}}
   {{- $authDiscovery := false -}}
-  {{- if (kindIs "boolean" $objectData.iscsi.authSession) -}}
-    {{- $authSession = $objectData.iscsi.authSession -}}
+  {{- if $objectData.iscsi.authSession -}}
+    {{- $authSession = true -}}
   {{- end -}}
-  {{- if (kindIs "boolean" $objectData.iscsi.authDiscovery) -}}
-    {{- $authDiscovery = $objectData.iscsi.authDiscovery -}}
+  {{- if $objectData.iscsi.authDiscovery -}}
+    {{- $authDiscovery = true -}}
   {{- end }}
 
 - name: {{ $objectData.shortName }}
@@ -67,8 +67,9 @@ objectData: The object data to be used to render the volume.
     {{- end }}
     chapAuthSession: {{ $authSession }}
     chapAuthDiscovery: {{ $authDiscovery }}
-    {{- if or $authSession $authDiscovery }}
+    {{- if or $authSession $authDiscovery -}}
+      {{- $secretName := (printf "%s-%s" (include "tc.v1.common.lib.chart.names.fullname" $rootCtx) $objectData.shortName) }}
     secretRef:
-        name: {{ $objectData.shortName }}
+        name: {{ $secretName }}
     {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/pod/volumes/_iscsi.tpl
+++ b/library/common/templates/lib/pod/volumes/_iscsi.tpl
@@ -34,6 +34,15 @@ objectData: The object data to be used to render the volume.
   {{- $lun := $objectData.iscsi.lun -}}
   {{- if (kindIs "string" $lun) -}}
     {{- $lun = tpl $lun $rootCtx | float64 -}}
+  {{- end -}}
+
+  {{- $authSession := false -}}
+  {{- $authDiscovery := false -}}
+  {{- if (kindIs "boolean" $objectData.iscsi.authSession) -}}
+    {{- $authSession = $objectData.iscsi.authSession -}}
+  {{- end -}}
+  {{- if (kindIs "boolean" $objectData.iscsi.authDiscovery) -}}
+    {{- $authDiscovery = $objectData.iscsi.authDiscovery -}}
   {{- end }}
 
 - name: {{ $objectData.shortName }}
@@ -55,6 +64,11 @@ objectData: The object data to be used to render the volume.
     {{- end -}}
     {{- with $objectData.iscsi.fsType }}
     fsType: {{ tpl . $rootCtx }}
+    {{- end }}
+    chapAuthSession: {{ $authSession }}
+    chapAuthDiscovery: {{ $authDiscovery }}
+    {{- if or $authSession $authDiscovery }}
+    secretRef:
+        name: {{ $objectData.shortName }}
     {{- end -}}
-    {{/* TODO: add chap auth support */}}
 {{- end -}}

--- a/library/common/templates/lib/storage/_iscsiChap.tpl
+++ b/library/common/templates/lib/storage/_iscsiChap.tpl
@@ -1,40 +1,40 @@
-{{- define "tc.v1.common.lib.iscsi.chap" -}}
+{{- define "tc.v1.common.lib.storage.iscsi.chap" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $data := dict -}}
 
   {{- if $objectData.iscsi.authSession -}}
-    {{- with $objectData.iscsi.chap.sessionUsername -}}
+    {{- with $objectData.iscsi.authSession.username -}}
       {{- $_ := set $data "node.session.auth.username" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.sessionPassword -}}
+    {{- with $objectData.iscsi.authSession.password -}}
       {{- $_ := set $data "node.session.auth.password" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.sessionUsernameInitiator -}}
+    {{- with $objectData.iscsi.authSession.usernameInitiator -}}
       {{- $_ := set $data "node.session.auth.username_in" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.sessionPasswordInitiator -}}
+    {{- with $objectData.iscsi.authSession.passwordInitiator -}}
       {{- $_ := set $data "node.session.auth.password_in" (tpl . $rootCtx) -}}
     {{- end -}}
   {{- end -}}
 
   {{- if $objectData.iscsi.authDiscovery -}}
-    {{- with $objectData.iscsi.chap.discoveryUsername -}}
+    {{- with $objectData.iscsi.authDiscovery.username -}}
       {{- $_ := set $data "discovery.sendtargets.auth.username" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.discoveryPassword -}}
+    {{- with $objectData.iscsi.authDiscovery.password -}}
       {{- $_ := set $data "discovery.sendtargets.auth.password" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.discoveryUsernameInitiator -}}
+    {{- with $objectData.iscsi.authDiscovery.usernameInitiator -}}
       {{- $_ := set $data "discovery.sendtargets.auth.username_in" (tpl . $rootCtx) -}}
     {{- end -}}
 
-    {{- with $objectData.iscsi.chap.discoveryPasswordInitiator -}}
+    {{- with $objectData.iscsi.authDiscovery.passwordInitiator -}}
       {{- $_ := set $data "discovery.sendtargets.auth.password_in" (tpl . $rootCtx) -}}
     {{- end -}}
   {{- end -}}

--- a/library/common/templates/lib/storage/_iscsiChap.tpl
+++ b/library/common/templates/lib/storage/_iscsiChap.tpl
@@ -39,5 +39,5 @@
     {{- end -}}
   {{- end -}}
 
-  {{- $data -}}
+  {{- $data | toJson -}}
 {{- end -}}

--- a/library/common/templates/lib/storage/_iscsiChap.tpl
+++ b/library/common/templates/lib/storage/_iscsiChap.tpl
@@ -1,0 +1,43 @@
+{{- define "tc.v1.common.lib.iscsi.chap" -}}
+  {{- $objectData := .objectData -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $data := dict -}}
+
+  {{- if $objectData.iscsi.authSession -}}
+    {{- with $objectData.iscsi.chap.sessionUsername -}}
+      {{- $_ := set $data "node.session.auth.username" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.sessionPassword -}}
+      {{- $_ := set $data "node.session.auth.password" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.sessionUsernameInitiator -}}
+      {{- $_ := set $data "node.session.auth.username_in" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.sessionPasswordInitiator -}}
+      {{- $_ := set $data "node.session.auth.password_in" (tpl . $rootCtx) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if $objectData.iscsi.authDiscovery -}}
+    {{- with $objectData.iscsi.chap.discoveryUsername -}}
+      {{- $_ := set $data "discovery.sendtargets.auth.username" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.discoveryPassword -}}
+      {{- $_ := set $data "discovery.sendtargets.auth.password" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.discoveryUsernameInitiator -}}
+      {{- $_ := set $data "discovery.sendtargets.auth.username_in" (tpl . $rootCtx) -}}
+    {{- end -}}
+
+    {{- with $objectData.iscsi.chap.discoveryPasswordInitiator -}}
+      {{- $_ := set $data "discovery.sendtargets.auth.password_in" (tpl . $rootCtx) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $data -}}
+{{- end -}}

--- a/library/common/templates/lib/storage/_validation.tpl
+++ b/library/common/templates/lib/storage/_validation.tpl
@@ -10,7 +10,7 @@ objectData:
   {{- $rootCtx := .rootCtx -}}
   {{- $objectData := .objectData -}}
 
-  {{- $types := (list "pvc" "vct" "emptyDir" "nfs" "hostPath" "ixVolume" "secret" "configmap" "device") -}}
+  {{- $types := (list "pvc" "vct" "emptyDir" "nfs" "iscsi" "hostPath" "ixVolume" "secret" "configmap" "device") -}}
   {{- if not (mustHas $objectData.type $types) -}}
     {{- fail (printf "Persistence - Expected [type] to be one of [%s], but got [%s]" (join ", " $types) $objectData.type) -}}
   {{- end -}}

--- a/library/common/templates/spawner/_pvc.tpl
+++ b/library/common/templates/spawner/_pvc.tpl
@@ -77,7 +77,7 @@
       {{- end -}}
 
       {{- if eq $objectData.type "iscsi" -}}
-        {{- if $objectData.iscsi.chap -}}
+        {{- if or $objectData.iscsi.authSession $objectData.iscsi.discoverySession -}}
           {{- $secretData := (dict
                                 "name" $objectData.name
                                 "labels" ($objectData.labels | default dict)

--- a/library/common/templates/spawner/_pvc.tpl
+++ b/library/common/templates/spawner/_pvc.tpl
@@ -77,13 +77,17 @@
       {{- end -}}
 
       {{- if eq $objectData.type "iscsi" -}}
-        {{- if or $objectData.iscsi.authSession $objectData.iscsi.discoverySession -}}
+        {{- if or $objectData.iscsi.authSession $objectData.iscsi.authDiscovery -}}
+          {{/* Set the name of the PVC */}}
+          {{- $_ := set $objectData "name" (include "tc.v1.common.lib.storage.pvc.name" (dict "rootCtx" $ "objectName" $name "objectData" $objectData)) -}}
+          {{- $_ := set $objectData "shortName" $name -}}
+
           {{- $secretData := (dict
                                 "name" $objectData.name
                                 "labels" ($objectData.labels | default dict)
                                 "annotations" ($objectData.annotations | default dict)
                                 "type" "kubernetes.io/iscsi-chap"
-                                "data" (include "tc.v1.common.lib.storage.iscsi.chap" (dict "rootCtx" $ "objectData" $objectData))
+                                "data" (include "tc.v1.common.lib.storage.iscsi.chap" (dict "rootCtx" $ "objectData" $objectData) | fromJson)
                               ) -}}
           {{- include "tc.v1.common.class.secret" (dict "rootCtx" $ "objectData" $secretData) -}}
         {{- end -}}

--- a/library/common/templates/spawner/_pvc.tpl
+++ b/library/common/templates/spawner/_pvc.tpl
@@ -75,6 +75,19 @@
         {{/* Call class to create the object */}}
         {{- include "tc.v1.common.class.pvc" (dict "rootCtx" $ "objectData" $objectData) -}}
       {{- end -}}
+
+      {{- if eq $objectData.type "iscsi" -}}
+        {{- if $objectData.iscsi.chap -}}
+          {{- $secretData := (dict
+                                "name" $objectData.name
+                                "labels" ($objectData.labels | default dict)
+                                "annotations" ($objectData.annotations | default dict)
+                                "type" "kubernetes.io/iscsi-chap"
+                                "data" (include "tc.v1.common.lib.storage.iscsi.chap" (dict "rootCtx" $ "objectData" $objectData))
+                              ) -}}
+          {{- include "tc.v1.common.class.secret" (dict "rootCtx" $ "objectData" $secretData) -}}
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -222,6 +222,17 @@ persistence:
     mountPath: /dev/shm
     medium: Memory
     targetSelectAll: true
+#  iscsi:
+#    enabled: true
+#    type: iscsi
+#    mountPath: /dev/shm
+#    iscsi:
+#      targetPortal: 10.0.2.15:3260
+#      portals: ['10.0.2.16:3260', '10.0.2.17:3260'] #optional
+#      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+#      lun: 0
+#      fsType: ext4 #Optional
+#      iscsiInterface: default #Optional
 #  vct:
 #    enabled: true
 #    type: vct

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -234,17 +234,16 @@ persistence:
 #      fsType: ext4 #Optional
 #      iscsiInterface: default #Optional
 #      initiatorName: iqn.1994-05.com.redhat:node1 #Optional
-#      authSession: false
-#      authDiscovery: false
-#      chap:
-#        sessionUsername:
-#        sessionPassword:
-#        sessionUsernameInitiator:
-#        sessionPasswordInitiator:
-#        discoveryUsername:
-#        discoveryPassword:
-#        discoveryUsernameInitiator:
-#        discoveryPasswordInitiator:
+#      authSession:
+#        username: "someusername"
+#        password: "somepassword"
+#        usernameInitiator: "someusernameInitiator"
+#        passwordInitiator: "somepasswordInitiator"
+#      authDiscovery:
+#        username: "someusername"
+#        password: "somepassword"
+#        usernameInitiator: "someusernameInitiator"
+#        passwordInitiator: "somepasswordInitiator"
 #  vct:
 #    enabled: true
 #    type: vct

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -233,6 +233,7 @@ persistence:
 #      lun: 0
 #      fsType: ext4 #Optional
 #      iscsiInterface: default #Optional
+#      initiatorName: iqn.1994-05.com.redhat:node1 #Optional
 #  vct:
 #    enabled: true
 #    type: vct

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -234,6 +234,17 @@ persistence:
 #      fsType: ext4 #Optional
 #      iscsiInterface: default #Optional
 #      initiatorName: iqn.1994-05.com.redhat:node1 #Optional
+#      authSession: false
+#      authDiscovery: false
+#      chap:
+#        sessionUsername:
+#        sessionPassword:
+#        sessionUsernameInitiator:
+#        sessionPasswordInitiator:
+#        discoveryUsername:
+#        discoveryPassword:
+#        discoveryUsernameInitiator:
+#        discoveryPasswordInitiator:
 #  vct:
 #    enabled: true
 #    type: vct


### PR DESCRIPTION
**Description**
Besides nfs, we can also allow mounting of iscsi volumes directly to pods.
Which should allow users more flexibility for using their prefered storage, primarily because it's also easy to implement in TrueNAS SCALE

⚒️ Fixes  #592

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
