### PR TITLE
feat(common): add namespace labeler and use includes instead

### DIFF
--- a/library/common-test/ci/namespace-values.yaml
+++ b/library/common-test/ci/namespace-values.yaml
@@ -1,0 +1,49 @@
+service:
+  main:
+    enabled: true
+    primary: true
+    ports:
+      main:
+        enabled: true
+        primary: true
+        protocol: http
+        port: 8080
+
+workload:
+  main:
+    enabled: true
+    primary: true
+    type: Deployment
+    podSpec:
+      containers:
+        main:
+          enabled: true
+          primary: true
+          args:
+            - --port
+            - "8080"
+          probes:
+            liveness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            readiness:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+            startup:
+              enabled: true
+              type: http
+              port: "{{ .Values.service.main.ports.main.port }}"
+
+namespace:
+  labels:
+    somelabel: somelabelvalue
+
+global:
+  namespace:
+    labels:
+      somegloballabel: someglobalvalue
+
+manifestManager:
+  enabled: false

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -13,7 +13,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.cert-manager.certificate.apiVe
 kind: Certificate
 metadata:
   name: {{ $name }}
-  namespace: {{ $root.Values.namespace | default $root.Values.global.namespace | default $root.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "certificate") }}
 spec:
   secretName: {{ $name }}
   dnsNames:

--- a/library/common/templates/class/_certificate.tpl
+++ b/library/common/templates/class/_certificate.tpl
@@ -13,7 +13,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.cert-manager.certificate.apiVe
 kind: Certificate
 metadata:
   name: {{ $name }}
-  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "certificate") }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $root "objectData" $objectData "caller" "certificate") }}
 spec:
   secretName: {{ $name }}
   dnsNames:

--- a/library/common/templates/class/_cnpgCluster.tpl
+++ b/library/common/templates/class/_cnpgCluster.tpl
@@ -18,7 +18,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.cnpg.cluster.apiVersion" $ }}
 kind: Cluster
 metadata:
   name: {{ $cnpgClusterName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "cnpgCluster") }}
   {{- $labels := (mustMerge ($cnpgClusterLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) }}
   labels:
     cnpg.io/reload: "on"

--- a/library/common/templates/class/_cnpgPooler.tpl
+++ b/library/common/templates/class/_cnpgPooler.tpl
@@ -20,7 +20,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.cnpg.pooler.apiVersion" $ }}
 kind: Pooler
 metadata:
   name: {{ printf "%v-%v" $cnpgClusterName $values.pooler.type }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "cnpgPooler") }}
 spec:
   cluster:
     name: {{ $cnpgClusterName }}

--- a/library/common/templates/class/_horizontalPodAutoscaler.tpl
+++ b/library/common/templates/class/_horizontalPodAutoscaler.tpl
@@ -24,7 +24,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $hpaName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "HPA") }}
   {{- $labels := (mustMerge ($hpaLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -81,7 +81,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ $ingressName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "ingress") }}
   {{- $labels := (mustMerge ($ingressLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_networkPolicy.tpl
+++ b/library/common/templates/class/_networkPolicy.tpl
@@ -22,7 +22,7 @@ kind: NetworkPolicy
 apiVersion: {{ include "tc.v1.common.capabilities.networkpolicy.apiVersion" $ }}
 metadata:
   name: {{ $networkPolicyName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "networkPolicy") }}
   {{- $labels := (mustMerge ($networkpolicyLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_podMonitor.tpl
+++ b/library/common/templates/class/_podMonitor.tpl
@@ -19,7 +19,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.podmonitor.apiVersion" $ }}
 kind: PodMonitor
 metadata:
   name: {{ $podmonitorName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "podmonitor") }}
   {{- $labels := (mustMerge ($podmonitorLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_prometheusRule.tpl
+++ b/library/common/templates/class/_prometheusRule.tpl
@@ -19,7 +19,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.prometheusrule.apiVersion" $ }
 kind: PrometheusRule
 metadata:
   name: {{ $prometheusruleName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "prometheusRule") }}
   {{- $labels := (mustMerge ($prometheusruleLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_route.tpl
+++ b/library/common/templates/class/_route.tpl
@@ -38,7 +38,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: {{ $routeKind }}
 metadata:
   name: {{ $fullName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "route") }}
   {{- $labels := (mustMerge ($routeLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/class/_serviceMonitor.tpl
+++ b/library/common/templates/class/_serviceMonitor.tpl
@@ -19,7 +19,7 @@ apiVersion: {{ include "tc.v1.common.capabilities.servicemonitor.apiVersion" $ }
 kind: ServiceMonitor
 metadata:
   name: {{ $servicemonitorName }}
-  namespace: {{ $.Values.namespace | default $.Values.global.namespace | default $.Release.Namespace }}
+  namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "serviceMonitor") }}
   {{- $labels := (mustMerge ($servicemonitorLabels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $ | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $ "labels" $labels) | trim) }}
   labels:

--- a/library/common/templates/lib/metadata/_namespace.tpl
+++ b/library/common/templates/lib/metadata/_namespace.tpl
@@ -5,11 +5,11 @@
 
   {{- $namespace := $rootCtx.Release.Namespace -}}
 
-  {{- with $rootCtx.Values.global.namespace -}}
+  {{- with $rootCtx.Values.global.namespace.name -}}
     {{- $namespace = tpl . $rootCtx -}}
   {{- end -}}
 
-  {{- with $rootCtx.Values.namespace -}}
+  {{- with $rootCtx.Values.namespace.name -}}
     {{- $namespace = tpl . $rootCtx -}}
   {{- end -}}
 

--- a/library/common/templates/lib/util/_namespaceLabel.tpl
+++ b/library/common/templates/lib/util/_namespaceLabel.tpl
@@ -1,5 +1,5 @@
 {{- define "tc.v1.common.lib.util.namespacelabel" -}}
-  {{- if or .Values.namespace.label .Values.global.namespace.label -}}
+  {{- if or .Values.namespace.name.label .Values.global.namespace.name.label -}}
     {{- $workload := include "tc.v1.common.lib.util.namespacelabel.workload" $ | fromYaml -}}
     {{- $rbac := include "tc.v1.common.lib.util.namespacelabel.rbac" $ | fromYaml -}}
     {{- $serviceaccount := include "tc.v1.common.lib.util.namespacelabel.serviceaccount" $ | fromYaml -}}
@@ -61,10 +61,10 @@ podSpec:
         - /bin/sh
         - -c
         - |
-          {{- range .Values.namespace.labels }}
+          {{- range .Values.namespace.name.labels }}
           kubectl label namespace {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "NamespaceLabel") }} {{ .key }}={{ .value }}
           {{- end }}
-          {{- range .Values.global.namespace.labels }}
+          {{- range .Values.global.namespace.name.labels }}
           kubectl label namespace {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "NamespaceLabel") }} {{ .key }}={{ .value }}
           {{- end }}
 {{- end -}}

--- a/library/common/templates/lib/util/_namespaceLabel.tpl
+++ b/library/common/templates/lib/util/_namespaceLabel.tpl
@@ -1,0 +1,86 @@
+{{- define "tc.v1.common.lib.util.namespacelabel" -}}
+  {{- if or .Values.namespace.label .Values.global.namespace.label -}}
+    {{- $workload := include "tc.v1.common.lib.util.namespacelabel.workload" $ | fromYaml -}}
+    {{- $rbac := include "tc.v1.common.lib.util.namespacelabel.rbac" $ | fromYaml -}}
+    {{- $serviceaccount := include "tc.v1.common.lib.util.namespacelabel.serviceaccount" $ | fromYaml -}}
+    {{- if $workload -}}
+        {{- if not (hasKey .Values "workload") -}}
+          {{- $_ := set .Values "workload" dict -}}
+        {{- end -}}
+      {{- $_ := set .Values.workload "namespacelabel" $workload -}}
+    {{- end -}}
+    {{- if $rbac -}}
+        {{- if not (hasKey .Values "rbac") -}}
+          {{- $_ := set .Values "rbac" dict -}}
+        {{- end -}}
+      {{- $_ := set .Values.rbac "namespacelabel" $rbac -}}
+    {{- end -}}
+    {{- if $serviceaccount -}}
+        {{- if not (hasKey .Values "serviceaccount") -}}
+          {{- $_ := set .Values "serviceaccount" dict -}}
+        {{- end -}}
+      {{- $_ := set .Values.serviceaccount "namespacelabel" $serviceaccount -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{- define "tc.v1.common.lib.util.namespacelabel.workload" -}}
+# -- (docs/workload/README.md)
+enabled: true
+primary: true
+type: job
+automountServiceAccountToken: true
+podSpec:
+  containers:
+    main:
+      annotations:
+        "helm.sh/hook": post-install,post-upgrade,post-rollback
+        "helm.sh/hook-delete-policy": hook-succeeded
+      enabled: true
+      primary: true
+      type: system
+      imageSelector: kubectlImage
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          add: []
+          drop:
+            - ALL
+      command:
+        - "/bin/sh"
+        - "-c"
+        - |
+        - /bin/sh
+        - -c
+        - |
+          {{- range .Values.namespace.labels }}
+          kubectl label namespace {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "NamespaceLabel") }} {{ .key }}={{ .value }}
+          {{- end }}
+          {{- range .Values.global.namespace.labels }}
+          kubectl label namespace {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "NamespaceLabel") }} {{ .key }}={{ .value }}
+          {{- end }}
+{{- end -}}
+
+{{- define "tc.v1.common.lib.util.namespacelabel.rbac" -}}
+enabled: true
+primary: false
+serviceAccounts:
+  - labelnamespace
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["namespace"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end -}}
+
+{{- define "tc.v1.common.lib.util.namespacelabel.serviceaccount" -}}
+enabled: true
+primary: false
+{{- end -}}

--- a/library/common/templates/loader/_init.tpl
+++ b/library/common/templates/loader/_init.tpl
@@ -52,4 +52,7 @@
   {{/* Append database wait containers to pods */}}
   {{- include "tc.v1.common.lib.deps.wait" $ }}
 
+  {{/* Append namespace label job, if needed */}}
+  {{- include "tc.v1.common.lib.util.namespacelabel" $ }}
+
 {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -6,7 +6,9 @@ global:
   annotations: {}
   # -- Set a global namespace
   # TODO: Currently some objects do not support this
-  namespace: ""
+  namespace:
+    name: ""
+    labels: []
   # -- Adds metalLB annotations to services
   addMetalLBAnnotations: true
   # -- Adds traefik annotations to services
@@ -60,7 +62,9 @@ fallbackDefaults:
       successThreshold: 1
 
 # -- Explicitly set a namespace for this chart only
-namespace: ""
+namespace:
+  name: ""
+  labels: []
 
 # -- Image values
 image:


### PR DESCRIPTION
**Description**
Helm, by default, cannot label its own namespace.
By adding a job, we can ensure our charts can actually label their own namespace regardless.

We also use multiple styles of referencing namespaces instead of the standardised include.

⚒️ Fixes  #595 

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
