### PR TITLE
fix(common): default /tmp and /var/logs to memory emptyDirtype

### DIFF
--- a/library/common-test/tests/addons/autoperms_test.yaml
+++ b/library/common-test/tests/addons/autoperms_test.yaml
@@ -173,7 +173,8 @@ tests:
           path: spec.template.spec.volumes
           content:
             name: tmp
-            emptyDir: {}
+            emptyDir:
+              medium: Memory
       - documentIndex: *jobDoc
         contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -508,7 +509,8 @@ tests:
           path: spec.template.spec.volumes
           content:
             name: tmp
-            emptyDir: {}
+            emptyDir:
+              medium: Memory
       - documentIndex: *jobDoc
         contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -93,9 +93,11 @@ tests:
               - name: shared
                 emptyDir: {}
               - name: tmp
-                emptyDir: {}
+                emptyDir:
+                  medium: Memory
               - name: varlogs
-                emptyDir: {}
+                emptyDir:
+                  medium: Memory
               - name: varrun
                 emptyDir:
                   medium: Memory

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 15.0.1
+version: 15.0.2

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -204,6 +204,7 @@ persistence:
     enabled: true
     type: emptyDir
     mountPath: /var/logs
+    medium: Memory
     targetSelectAll: true
   varrun:
     enabled: true
@@ -215,6 +216,7 @@ persistence:
     enabled: true
     type: emptyDir
     mountPath: /tmp
+    medium: Memory
     targetSelectAll: true
   devshm:
     enabled: true


### PR DESCRIPTION
**Description**
This should limit the iops saturation of certain apps a bit

⚒️ Fixes  #601

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
