### PR TITLE
fix(common): limit default emptydir size for memory emptyDir

### DIFF
--- a/library/common-test/tests/addons/autoperms_test.yaml
+++ b/library/common-test/tests/addons/autoperms_test.yaml
@@ -175,6 +175,7 @@ tests:
             name: tmp
             emptyDir:
               medium: Memory
+              sizeLimit: 8Gi
       - documentIndex: *jobDoc
         contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -511,6 +512,7 @@ tests:
             name: tmp
             emptyDir:
               medium: Memory
+              sizeLimit: 8Gi
       - documentIndex: *jobDoc
         contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -90,17 +90,20 @@ tests:
               - name: devshm
                 emptyDir:
                   medium: Memory
+                  sizeLimit: 8Gi
               - name: shared
                 emptyDir: {}
               - name: tmp
                 emptyDir:
                   medium: Memory
+                  sizeLimit: 8Gi
               - name: varlogs
                 emptyDir:
                   medium: Memory
               - name: varrun
                 emptyDir:
                   medium: Memory
+                  sizeLimit: 8Gi
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.containers[0]

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -100,6 +100,7 @@ tests:
               - name: varlogs
                 emptyDir:
                   medium: Memory
+                  sizeLimit: 8Gi
               - name: varrun
                 emptyDir:
                   medium: Memory

--- a/library/common-test/tests/defaults/defaults-test.yaml
+++ b/library/common-test/tests/defaults/defaults-test.yaml
@@ -93,7 +93,8 @@ tests:
               - name: shared
                 emptyDir: {}
               - name: tmp
-                emptyDir: {}
+                emptyDir:
+                  medium: Memory
               - name: varlogs
                 emptyDir: {}
               - name: varrun

--- a/library/common-test/tests/pod/volume_emptyDIr_test.yaml
+++ b/library/common-test/tests/pod/volume_emptyDIr_test.yaml
@@ -81,6 +81,7 @@ tests:
             name: emptyDir-vol
             emptyDir:
               medium: Memory
+              sizeLimit: 8Gi
 
   - it: should pass with emptyDir volume with size set
     set:
@@ -106,6 +107,65 @@ tests:
             name: emptyDir-vol
             emptyDir:
               sizeLimit: 3Gi
+
+  - it: should pass with emptyDir volume with medium Memory and size from resource limits
+    set:
+      resources:
+        limits:
+          memory: 500Mi
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        emptyDir-vol:
+          enabled: true
+          type: emptyDir
+          medium: Memory
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: emptyDir-vol
+            emptyDir:
+              medium: Memory
+              sizeLimit: 500Mi
+
+  - it: should pass with emptyDir volume with medium Memory and size override
+    set:
+      resources:
+        limits:
+          memory: 500Mi
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+      persistence:
+        emptyDir-vol:
+          enabled: true
+          type: emptyDir
+          medium: Memory
+          size: 1Gi
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: emptyDir-vol
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi
 
 # Failures
   - it: should fail with invalid medium in emptyDir

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 15.0.1
+version: 15.0.2

--- a/library/common/templates/lib/pod/volumes/_emptyDir.tpl
+++ b/library/common/templates/lib/pod/volumes/_emptyDir.tpl
@@ -23,6 +23,8 @@ objectData: The object data to be used to render the volume.
       {{- $formats := "(Suffixed with E/P/T/G/M/K - eg. 1G), (Suffixed with Ei/Pi/Ti/Gi/Mi/Ki - eg. 1Gi), (Plain Integer in bytes - eg. 1024), (Exponent - eg. 134e6)" -}}
       {{- fail (printf "Persistence Expected [size] to have one of the following formats [%s], but got [%s]" $formats $size) -}}
     {{- end -}}
+  {{- else if eq $medium "Memory" -}}
+    {{- $size = $rootCtx.Values.resources.limits.memory -}}
   {{- end -}}
 
   {{- if and $medium (ne $medium "Memory") -}}
@@ -36,8 +38,6 @@ objectData: The object data to be used to render the volume.
     {{- end -}}
     {{- if $size }}
     sizeLimit: {{ $size }}
-    {{- else if eq $medium "Memory" }}
-    sizeLimit: {{ $size | default $rootCtx.Values.resources.limits.memory }}
     {{- end -}}
   {{- else }}
   emptyDir: {}

--- a/library/common/templates/lib/pod/volumes/_emptyDir.tpl
+++ b/library/common/templates/lib/pod/volumes/_emptyDir.tpl
@@ -36,7 +36,7 @@ objectData: The object data to be used to render the volume.
     {{- end -}}
     {{- if $size }}
     sizeLimit: {{ $size }}
-    {{- else if eq medium "Memory" }}
+    {{- else if eq $medium "Memory" }}
     sizeLimit: {{ $size | default $rootCtx.resources.limits.memory }}
     {{- end -}}
   {{- else }}

--- a/library/common/templates/lib/pod/volumes/_emptyDir.tpl
+++ b/library/common/templates/lib/pod/volumes/_emptyDir.tpl
@@ -37,7 +37,7 @@ objectData: The object data to be used to render the volume.
     {{- if $size }}
     sizeLimit: {{ $size }}
     {{- else if eq $medium "Memory" }}
-    sizeLimit: {{ $size | default $rootCtx.resources.limits.memory }}
+    sizeLimit: {{ $size | default $rootCtx.Values.resources.limits.memory }}
     {{- end -}}
   {{- else }}
   emptyDir: {}

--- a/library/common/templates/lib/pod/volumes/_emptyDir.tpl
+++ b/library/common/templates/lib/pod/volumes/_emptyDir.tpl
@@ -36,6 +36,8 @@ objectData: The object data to be used to render the volume.
     {{- end -}}
     {{- if $size }}
     sizeLimit: {{ $size }}
+    {{- else if eq medium "Memory" }}
+    sizeLimit: {{ $size | default $rootCtx.resources.limits.memory }}
     {{- end -}}
   {{- else }}
   emptyDir: {}


### PR DESCRIPTION
**Description**
Currently emptyDir ramdisks are set to have unlimited size.
This puts a limit to that, sized in accordance to .values.resources.limits.memory

Yes this means an App consuming all space in an emptyDir can exceed the limits, but at least it prevents attacks where host OOMs can be triggered by oversaturating a memory-backed emptyDir

⚒️ Fixes  #602 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
