### PR TITLE
feat(common): allow for imagePullSecrets to be input in a list for scale GUI

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~15.0.0
+  version: ~15.2.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~15.2.0
+  version: ~15.1.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/tests/imagePullSecret/data_test.yaml
+++ b/library/common-test/tests/imagePullSecret/data_test.yaml
@@ -49,3 +49,23 @@ tests:
           path: data
           value:
             .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7ImF1dGgiOiJkWE5sY2pwelpXTnlaWFJmY0dGemN3PT0iLCJlbWFpbCI6Im1haWxAZXhhbXBsZS5jb20iLCJwYXNzd29yZCI6InNlY3JldF9wYXNzIiwidXNlcm5hbWUiOiJ1c2VyIn19fQ==
+
+  - it: should pass with  data from tpl
+    set:
+      registry: quay.io
+      user: user
+      pass: secret_pass
+      email: mail@example.com
+      imagePullSecretList:
+        - enabled: true
+          data:
+            registry: "{{ .Values.registry }}"
+            username: "{{ .Values.user }}"
+            password: "{{ .Values.pass }}"
+            email: "{{ .Values.email }}"
+    asserts:
+      - documentIndex: *secretDoc
+        equal:
+          path: data
+          value:
+            .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7ImF1dGgiOiJkWE5sY2pwelpXTnlaWFJmY0dGemN3PT0iLCJlbWFpbCI6Im1haWxAZXhhbXBsZS5jb20iLCJwYXNzd29yZCI6InNlY3JldF9wYXNzIiwidXNlcm5hbWUiOiJ1c2VyIn19fQ==

--- a/library/common-test/tests/imagePullSecret/name_test.yaml
+++ b/library/common-test/tests/imagePullSecret/name_test.yaml
@@ -22,6 +22,13 @@ tests:
             username: user2
             password: pass2
             email: mail2
+      imagePullSecretList:
+        - enabled: true
+          data:
+            registry: reg1
+            username: user1
+            password: pass1
+            email: mail1
     asserts:
       - documentIndex: &secretDoc 0
         isKind:
@@ -43,3 +50,13 @@ tests:
         equal:
           path: metadata.name
           value: test-release-name-common-test-my-pull-secret2
+      - documentIndex: &thirdSecretDoc 2
+        isKind:
+          of: Secret
+      - documentIndex: *thirdSecretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *thirdSecretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-pullsecret-list-0

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 15.0.2
+version: 15.2.0

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 15.2.0
+version: 15.1.0

--- a/library/common/templates/loader/_lists.tpl
+++ b/library/common/templates/loader/_lists.tpl
@@ -1,5 +1,7 @@
 {{- define "tc.v1.common.loader.lists" -}}
 
+  {{- include "tc.v1.common.values.imagePullList" . -}}
+
   {{- include "tc.v1.common.values.persistenceList" . -}}
 
   {{- include "tc.v1.common.values.deviceList" . -}}

--- a/library/common/templates/loader/_lists.tpl
+++ b/library/common/templates/loader/_lists.tpl
@@ -1,6 +1,6 @@
 {{- define "tc.v1.common.loader.lists" -}}
 
-  {{- include "tc.v1.common.values.imagePullList" . -}}
+  {{- include "tc.v1.common.values.imagePullSecretList" . -}}
 
   {{- include "tc.v1.common.values.persistenceList" . -}}
 

--- a/library/common/templates/values/lists/_imagePullSecretList.tpl
+++ b/library/common/templates/values/lists/_imagePullSecretList.tpl
@@ -1,0 +1,18 @@
+{{- define "tc.v1.common.values.imagePullSecretList" -}}
+  {{- $rootCtx := . -}}
+
+  {{- range $idx, $imagePullSecretValues := $rootCtx.Values.imagePullSecretList -}}
+
+      {{- $name := (printf "pullSecret-list-%s" (toString $idx)) -}}
+
+      {{- with $imagePullSecretValues.name -}}
+        {{- $name = . -}}
+      {{- end -}}
+
+      {{- if not (hasKey $rootCtx.Values "imagePullSecret") -}}
+        {{- $_ := set $rootCtx.Values "imagePullSecret" dict -}}
+      {{- end -}}
+
+      {{- $_ := set $rootCtx.Values.imagePullSecret $name $imagePullSecretValues -}}
+  {{- end -}}
+{{- end -}}

--- a/library/common/templates/values/lists/_imagePullSecretList.tpl
+++ b/library/common/templates/values/lists/_imagePullSecretList.tpl
@@ -3,7 +3,7 @@
 
   {{- range $idx, $imagePullSecretValues := $rootCtx.Values.imagePullSecretList -}}
 
-      {{- $name := (printf "pullSecret-list-%s" (toString $idx)) -}}
+      {{- $name := (printf "pullsecret-list-%s" (toString $idx)) -}}
 
       {{- with $imagePullSecretValues.name -}}
         {{- $name = . -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -326,7 +326,10 @@ ixCertificates: []
 ixVolumes: []
 
 # -- (docs/imagePullSecrets.md)
-imagePullSecret: []
+imagePullSecret: {}
+
+# -- (docs/imagePullSecrets.md)
+imagePullSecretList: []
 
 # -- (docs/configmap.md)
 configmap: {}
@@ -436,7 +439,7 @@ alpineImage:
 
 scratchImage:
   repository: tccr.io/truecharts/scratch
-  tag: latest@sha256:e7d1aaa6e29e7bcf3e3f13a8fc41803ca81b2614f72d11287ca4dcab4850bd99
+  tag: latest@sha256:7f821eeb99d04ac248c47f79cfbcc2482651fea48aff9ec5d2ba0ba34f1f5531
   pullPolicy: IfNotPresent
 
 kubectlImage:
@@ -497,6 +500,26 @@ ingress:
   main:
     # -- Enables or disables the ingress
     enabled: false
+
+    # -- Adds integrations to ingress
+#    integration:
+#      homepage:
+#        enabled: true
+#        # Default: chart name
+#        name: somename
+#        # Default: chart description
+#        description: some description
+#        group: somegroup
+#        # Default: chart icon
+#        icon: icon.png
+#        pod-selector: ""
+#        widget:
+#          # Default: chartname
+#          type: "sometype"
+#          # Default: host-path of first ingress
+#          url: "https://example.com"
+#          custom:
+#            - somesetting: some value
 
     # -- Make this the primary ingress (used in probes, notes, etc...).
     # If there is more than 1 ingress, make sure that only 1 ingress is marked as primary.


### PR DESCRIPTION
**Description**
On scale it would be best to render imagePullSecrets as a list in the GUI

⚒️ Fixes  #600

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
