### PR TITLE
fix(common): Bugfixes on codeserver ingress

### DIFF
--- a/library/common/templates/addons/code-server/_codeserver.tpl
+++ b/library/common/templates/addons/code-server/_codeserver.tpl
@@ -40,11 +40,12 @@ It will include / inject the required templates based on the given values.
     {{- $_ := set $ingressValues "nameOverride" "codeserver" -}}
 
     {{/* Determine the target service name & port */}}
-    {{- $svcName := printf "%v-codeserver" (include "tc.v1.common.names.fullname" .) -}}
+    {{- $svcName := printf "%v-codeserver" (include "tc.v1.common.lib.chart.names.fullname" .) -}}
     {{- $svcPort := .Values.addons.codeserver.service.ports.codeserver.port -}}
     {{- range $_, $host := $ingressValues.hosts -}}
       {{- $_ := set (index $host.paths 0) "service" (dict "name" $svcName "port" $svcPort) -}}
     {{- end -}}
+    {{- $_ := set $ingressValues "name" $svcName -}}
     {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
     {{- include "tc.v1.common.class.ingress" $ -}}
     {{- $_ := unset $ "ObjectValues" -}}

--- a/library/common/templates/lib/util/_verify_operator.tpl
+++ b/library/common/templates/lib/util/_verify_operator.tpl
@@ -19,9 +19,6 @@
         {{- $ingress = true -}}
       {{- end -}}
     {{- end -}}
-    {{- if $.Values.addons.codeserver.ingress.enabled -}}
-      {{- $ingress = true -}}
-    {{- end -}}
     {{- if $ingress -}}
       {{- $operatorList = mustAppend $operatorList "traefik" -}}
     {{- end -}}

--- a/library/common/templates/lib/util/_verify_operator.tpl
+++ b/library/common/templates/lib/util/_verify_operator.tpl
@@ -19,6 +19,9 @@
         {{- $ingress = true -}}
       {{- end -}}
     {{- end -}}
+    {{- if $.Values.addons.codeserver.ingress.enabled -}}
+      {{- $ingress = true -}}
+    {{- end -}}
     {{- if $ingress -}}
       {{- $operatorList = mustAppend $operatorList "traefik" -}}
     {{- end -}}


### PR DESCRIPTION
**Description**
The codeserver ingress uses a non existent include to get the fullname. It also does not set a name for the ingress, causing the resulting ingress resource have no name which kubernetes does not accept. It also uses the wrong namespace for middleware when no other regular ingresses are configured due to the operator verification only checking `.Values.ingress`.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Applying the fixes locally and running the updated code. The codeserver ingress got deployed without problems and worked perfectly.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
