### PR TITLE
fix(loadbalancerIP): remove loadbalancerIP from service spec and only use annotations

### DIFF
--- a/library/common-test/tests/service/load_balancer_test.yaml
+++ b/library/common-test/tests/service/load_balancer_test.yaml
@@ -12,6 +12,9 @@ tests:
           enabled: true
           primary: true
           type: LoadBalancer
+          loadBalancerIPs:
+            - 1.2.3.4
+            - 5.6.7.8
           ports:
             port-name:
               enabled: true
@@ -50,6 +53,11 @@ tests:
               app.kubernetes.io/instance: test-release-name
               app.kubernetes.io/name: common-test
               pod.name: my-workload
+      - documentIndex: *serviceDoc
+        isSubset:
+          path: metadata.annotations
+          content:
+            metallb.universe.tf/loadBalancerIPs: "1.2.3.4,5.6.7.8"
 
   - it: should pass with type LoadBalancer and available options set
     set:
@@ -111,7 +119,6 @@ tests:
           value:
             type: LoadBalancer
             clusterIP: 172.16.20.35
-            loadBalancerIP: 10.100.200.45
             loadBalancerSourceRanges:
               - 11.100.200.0/24
               - 10.100.200.0/24

--- a/library/common-test/tests/service/validation_test.yaml
+++ b/library/common-test/tests/service/validation_test.yaml
@@ -559,7 +559,8 @@ tests:
           enabled: true
           primary: true
           type: LoadBalancer
-          loadBalancerIP: []
+          loadBalancerIP:
+            - 1.2.3.4
           ports:
             port-name:
               enabled: true

--- a/library/common-test/tests/service/validation_test.yaml
+++ b/library/common-test/tests/service/validation_test.yaml
@@ -539,6 +539,7 @@ tests:
         my-service1:
           enabled: true
           primary: true
+          type: LoadBalancer
           loadBalancerIP: 1.2.3.4
           loadBalancerIPs:
             - 1.2.3.4
@@ -557,6 +558,7 @@ tests:
         my-service1:
           enabled: true
           primary: true
+          type: LoadBalancer
           loadBalancerIP: []
           ports:
             port-name:
@@ -573,6 +575,7 @@ tests:
         my-service1:
           enabled: true
           primary: true
+          type: LoadBalancer
           loadBalancerIPs: not-a-slice
           ports:
             port-name:

--- a/library/common-test/tests/service/validation_test.yaml
+++ b/library/common-test/tests/service/validation_test.yaml
@@ -532,3 +532,53 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: Service - Namespace [my-namespace] expected to have [ix-] prefix when installed in TrueNAS SCALE
+
+  - it: should fail with both loadBalancerIP and loadBalancerIPs defined
+    set:
+      service:
+        my-service1:
+          enabled: true
+          primary: true
+          loadBalancerIP: 1.2.3.4
+          loadBalancerIPs:
+            - 1.2.3.4
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12345
+    asserts:
+      - failedTemplate:
+          errorMessage: Service - Expected on of [loadBalancerIP, loadBalancerIPs] to be defined but got both
+
+  - it: should fail with if loadBalancerIP is not a string
+    set:
+      service:
+        my-service1:
+          enabled: true
+          primary: true
+          loadBalancerIP: []
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12345
+    asserts:
+      - failedTemplate:
+          errorMessage: Service - Expected [loadBalancerIP] to be a string, but got [slice]
+
+  - it: should fail with if loadBalancerIPs is not a slice
+    set:
+      service:
+        my-service1:
+          enabled: true
+          primary: true
+          loadBalancerIPs: not-a-slice
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12345
+    asserts:
+      - failedTemplate:
+          errorMessage: Service - Expected [loadBalancerIPs] to be a slice, but got [string]

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 16.2.20
+version: 16.2.21

--- a/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
+++ b/library/common/templates/lib/service/serviceTypeSpecs/_loadBalancer.tpl
@@ -16,10 +16,6 @@ publishNotReadyAddresses: {{ include "tc.v1.common.lib.service.publishNotReadyAd
 externalIPs:
     {{- . | nindent 2 }}
   {{- end -}}
-  {{- with $objectData.loadBalancerIP }}
-loadBalancerIP: {{ tpl . $rootCtx }}
-  {{- end -}}
-
   {{- with $objectData.loadBalancerSourceRanges }}
 loadBalancerSourceRanges:
     {{- range . }}

--- a/library/common/templates/lib/util/_chartcontext.tpl
+++ b/library/common/templates/lib/util/_chartcontext.tpl
@@ -159,8 +159,10 @@
       {{- end -}}
 
       {{- if eq $selectedService.type "LoadBalancer" -}}
-        {{- with $selectedService.loadBalancerIP -}}
-          {{- $host = tpl . $rootCtx | toString -}}
+        {{- if (kindIs "string" $selectedService.loadBalancerIP) -}}
+          {{- with $selectedService.loadBalancerIP -}}
+            {{- $host = tpl . $rootCtx | toString -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

https://github.com/kubernetes/kubernetes/pull/107235

```sh
Failed to allocate IP for "ix-blocky/blocky-dot": service can not have both metallb.universe.tf/loadBalancerIPs and svc.Spec.LoadBalancerIP
```

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
