### PR TITLE
fix(common): ensure no loadbalancer reservation is made and ingress is not connected to ingresscontroller with Stop-All set

### DIFF
--- a/library/common-test/tests/ingress/stop_test.yaml
+++ b/library/common-test/tests/ingress/stop_test.yaml
@@ -45,7 +45,7 @@ tests:
       - documentIndex: *ingressDoc
         equal:
           path: spec.ingressClassName
-          value: stopped
+          value: tc-stopped
 
   - it: should pass with ixChartContext - isStopped (true)
     set:
@@ -68,7 +68,7 @@ tests:
       - documentIndex: *ingressDoc
         equal:
           path: spec.ingressClassName
-          value: stopped
+          value: tc-stopped
 
   - it: should pass with ixChartContext - isStopped (false)
     set:

--- a/library/common-test/tests/ingress/stop_test.yaml
+++ b/library/common-test/tests/ingress/stop_test.yaml
@@ -1,0 +1,93 @@
+suite: ingress - stop test
+templates:
+  - common.yaml
+chart:
+  appVersion: &appVer v9.9.9
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should pass with stopAll
+    set:
+      operator: &operator
+        verify:
+          enabled: false
+      global:
+        stopAll: true
+      service: &service
+        my-service:
+          enabled: true
+          primary: true
+          ports:
+            main:
+              enabled: true
+              primary: true
+              port: 80
+      ingress: &ingress
+        my-ingress:
+          enabled: true
+          primary: true
+          hosts:
+            - host: test-host
+              paths:
+                - path: /test-path
+          integrations:
+            traefik:
+              enabled: false
+    asserts:
+      - documentIndex: &ingressDoc 1
+        isKind:
+          of: Ingress
+      - documentIndex: *ingressDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *ingressDoc
+        equal:
+          path: spec.ingressClassName
+          value: stopped
+
+  - it: should pass with ixChartContext - isStopped (true)
+    set:
+      operator: *operator
+      global:
+        namespace: ix-something
+        ixChartContext:
+          storageClassName: some-storage-class
+          isStopped: true
+      service: *service
+      ingress: *ingress
+    asserts:
+      - documentIndex: &ingressDoc 1
+        isKind:
+          of: Ingress
+      - documentIndex: *ingressDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *ingressDoc
+        equal:
+          path: spec.ingressClassName
+          value: stopped
+
+  - it: should pass with ixChartContext - isStopped (false)
+    set:
+      operator: *operator
+      global:
+        namespace: ix-something
+        ixChartContext:
+          storageClassName: some-storage-class
+          isStopped: false
+      service: *service
+      ingress: *ingress
+    asserts:
+      - documentIndex: &ingressDoc 1
+        isKind:
+          of: Ingress
+      - documentIndex: *ingressDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *ingressDoc
+        isNull:
+          path: spec.ingressClassName

--- a/library/common-test/tests/ingress/validation_test.yaml
+++ b/library/common-test/tests/ingress/validation_test.yaml
@@ -610,3 +610,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: Ingress - [tls.scaleCert] can only be used in TrueNAS SCALE
+
+  - it: should fail with ingressClassName set to tc-stopped
+    set:
+      operator: *operator
+      service: *service
+      ingress:
+        my-ingress:
+          enabled: true
+          primary: true
+          hosts: *hosts
+          ingressClassName: tc-stopped
+    asserts:
+      - failedTemplate:
+          errorMessage: Ingress - Expected [ingressClassName] to not be [stopped], this is reserved for internal use

--- a/library/common-test/tests/service/stop_test.yaml
+++ b/library/common-test/tests/service/stop_test.yaml
@@ -1,0 +1,120 @@
+suite: service stop test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should pass with stopAll
+    set:
+      global:
+        stopAll: true
+      service: &service
+        my-service1:
+          enabled: true
+          primary: true
+          type: LoadBalancer
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12344
+      workload: &workload
+        my-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+    asserts:
+      - documentIndex: &serviceDoc 1
+        isKind:
+          of: Service
+      - documentIndex: *serviceDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *serviceDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *serviceDoc
+        equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should pass with isStopped (true)
+    set:
+      global:
+        namespace: ix-something
+        ixChartContext:
+          storageClassName: some-storage-class
+          isStopped: true
+      service: &service
+        my-service1:
+          enabled: true
+          primary: true
+          type: LoadBalancer
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12344
+      workload: &workload
+        my-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+    asserts:
+      - documentIndex: &serviceDoc 1
+        isKind:
+          of: Service
+      - documentIndex: *serviceDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *serviceDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *serviceDoc
+        equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should pass with isStopped (false)
+    set:
+      global:
+        namespace: ix-something
+        ixChartContext:
+          storageClassName: some-storage-class
+          isStopped: false
+      service: &service
+        my-service1:
+          enabled: true
+          primary: true
+          type: LoadBalancer
+          ports:
+            port-name:
+              enabled: true
+              primary: true
+              port: 12344
+      workload: &workload
+        my-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+    asserts:
+      - documentIndex: &serviceDoc 1
+        isKind:
+          of: Service
+      - documentIndex: *serviceDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *serviceDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test
+      - documentIndex: *serviceDoc
+        equal:
+          path: spec.type
+          value: LoadBalancer

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 16.2.21
+version: 16.2.22

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -23,13 +23,13 @@ objectData: The object data to be used to render the Ingress.
 
   {{- include "tc.v1.common.lib.ingress.integration.certManager" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
   {{- include "tc.v1.common.lib.ingress.integration.traefik" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- include "tc.v1.common.lib.ingress.integration.homepage" (dict "rootCtx" $rootCtx "objectData" $objectData) }}
-  
+  {{- include "tc.v1.common.lib.ingress.integration.homepage" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+
   {{/* When Stop All is set, force ingressClass "stopped" to yeet ingress from the ingresscontroller */}}
   {{- $ingressClassName := (tpl $objectData.ingressClassName $rootCtx) -}}
   {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
     {{- $ingressClassName = "stopped" -}}
-  {{- end -}}
+  {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -47,7 +47,7 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if $objectData.ingressClassName }}
+  {{- if $ingressClassName }}
   ingressClassName: {{ $ingressClassName }}
   {{- end }}
   rules:

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -25,8 +25,13 @@ objectData: The object data to be used to render the Ingress.
   {{- include "tc.v1.common.lib.ingress.integration.traefik" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
   {{- include "tc.v1.common.lib.ingress.integration.homepage" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
 
-  {{/* When Stop All is set, force ingressClass "stopped" to yeet ingress from the ingresscontroller */}}
-  {{- $ingressClassName := (tpl $objectData.ingressClassName $rootCtx) -}}
+  {{- $ingressClassName := "" -}}
+  {{- if $objectData.ingressClassName -}}
+    {{- $ingressClassName = (tpl $objectData.ingressClassName $rootCtx) -}}
+  {{- end -}}
+
+  {{/* When Stop All is set, force ingressClass "stopped"
+  to yeet ingress from the ingresscontroller */}}
   {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
     {{- $ingressClassName = "stopped" -}}
   {{- end }}

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -33,7 +33,7 @@ objectData: The object data to be used to render the Ingress.
   {{/* When Stop All is set, force ingressClass "stopped"
   to yeet ingress from the ingresscontroller */}}
   {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
-    {{- $ingressClassName = "stopped" -}}
+    {{- $ingressClassName = "tc-stopped" -}}
   {{- end }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/library/common/templates/class/_ingress.tpl
+++ b/library/common/templates/class/_ingress.tpl
@@ -24,6 +24,12 @@ objectData: The object data to be used to render the Ingress.
   {{- include "tc.v1.common.lib.ingress.integration.certManager" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
   {{- include "tc.v1.common.lib.ingress.integration.traefik" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
   {{- include "tc.v1.common.lib.ingress.integration.homepage" (dict "rootCtx" $rootCtx "objectData" $objectData) }}
+  
+  {{/* When Stop All is set, force ingressClass "stopped" to yeet ingress from the ingresscontroller */}}
+  {{- $ingressClassName := (tpl $objectData.ingressClassName $rootCtx) -}}
+  {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
+    {{- $ingressClassName = "stopped" -}}
+  {{- end -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -42,7 +48,7 @@ metadata:
   {{- end }}
 spec:
   {{- if $objectData.ingressClassName }}
-  ingressClassName: {{ tpl $objectData.ingressClassName $rootCtx }}
+  ingressClassName: {{ $ingressClassName }}
   {{- end }}
   rules:
     {{- range $h := $objectData.hosts }}

--- a/library/common/templates/class/_service.tpl
+++ b/library/common/templates/class/_service.tpl
@@ -51,14 +51,12 @@ objectData: The service data, that will be used to render the Service object.
       {{- $svcType = "ClusterIP" -}}
     {{- end -}}
   {{- end -}}
-  
+
   {{/* When Stop All is set, force ClusterIP as well */}}
   {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
     {{- $svcType = "ClusterIP" -}}
   {{- end -}}
   {{- $_ := set $objectData "type" $svcType  }}
-  
-
 ---
 apiVersion: v1
 kind: Service

--- a/library/common/templates/class/_service.tpl
+++ b/library/common/templates/class/_service.tpl
@@ -51,7 +51,13 @@ objectData: The service data, that will be used to render the Service object.
       {{- $svcType = "ClusterIP" -}}
     {{- end -}}
   {{- end -}}
+  
+  {{/* When Stop All is set, force ClusterIP as well */}}
+  {{- if (include "tc.v1.common.lib.util.stopAll" $rootCtx) -}}
+    {{- $svcType = "ClusterIP" -}}
+  {{- end -}}
   {{- $_ := set $objectData "type" $svcType  }}
+  
 
 ---
 apiVersion: v1

--- a/library/common/templates/lib/ingress/_validation.tpl
+++ b/library/common/templates/lib/ingress/_validation.tpl
@@ -31,6 +31,13 @@ objectData:
     {{- end -}}
   {{- end -}}
 
+  {{- if $objectData.ingressClassName -}}
+    {{- $icn := tpl $objectData.ingressClassName $rootCtx -}}
+    {{- if eq $icn "tc-stopped" -}}
+      {{- fail "Ingress - Expected [ingressClassName] to not be [stopped], this is reserved for internal use" -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- if not $objectData.hosts -}}
     {{- fail "Ingress - Expected non-empty [hosts]" -}}
   {{- end -}}


### PR DESCRIPTION
**Description**
Currently ingress and loadbalancer reservations are still being made for stopped charts.

With this change we set services to clusterip, to prevent external connections.
We also set ingress to a special `stopped` ingressClass, this ensures we don't nuke things like certificates when stopping

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
