### PR TITLE
fix(homepage integration): use release.name instead of chart.name for homepage name component

### DIFF
--- a/library/common-test/tests/ingress/homepage_test.yaml
+++ b/library/common-test/tests/ingress/homepage_test.yaml
@@ -100,7 +100,7 @@ tests:
           path: metadata.annotations
           value:
             gethomepage.dev/enabled: "true"
-            gethomepage.dev/name: CommonTest
+            gethomepage.dev/name: TestReleaseName
             gethomepage.dev/description: Helper chart to test different use cases of the common library
             gethomepage.dev/href: https://test-host/test-path
             gethomepage.dev/widget.url: https://test-release-name-common-test.test-release-namespace.svc:9443
@@ -151,7 +151,7 @@ tests:
           path: metadata.annotations
           value:
             gethomepage.dev/enabled: "true"
-            gethomepage.dev/name: CommonTest
+            gethomepage.dev/name: TestReleaseName
             gethomepage.dev/description: Helper chart to test different use cases of the common library
             gethomepage.dev/href: https://test-host/test-path
             gethomepage.dev/widget.url: http://test-release-name-common-test-my-service2.test-release-namespace.svc:80

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 16.2.22
+version: 16.2.23

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -10,7 +10,7 @@
 
     {{- include "tc.v1.common.lib.ingress.integration.homepage.validation" (dict "objectData" $objectData) -}}
 
-    {{- $name := $homepage.name | default ($rootCtx.Chart.Name | camelcase) -}}
+    {{- $name := $homepage.name | default ($rootCtx.Release.Name | camelcase) -}}
     {{- $desc := $homepage.description | default $rootCtx.Chart.Description -}}
     {{- $icon := $homepage.icon | default $rootCtx.Chart.Icon -}}
     {{- $defaultType := $rootCtx.Chart.Name | lower -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #654
**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
