### PR TITLE
fix(homepage): allow to disable widget

### DIFF
--- a/library/common-test/tests/ingress/homepage_test.yaml
+++ b/library/common-test/tests/ingress/homepage_test.yaml
@@ -91,6 +91,25 @@ tests:
             - host: "{{ .Values.someHost }}"
               paths:
                 - path: "{{ .Values.somePath }}"
+        my-ingress4:
+          enabled: true
+          hosts: *hosts
+          integrations:
+            traefik: *traefik
+            homepage:
+              enabled: true
+              widget:
+                enabled: false
+                url: some-url-4
+                type: some-type-4
+                custom:
+                  some-key: some-value
+                  some-other-key: some-other-value
+                customkv:
+                  - key: some-key-slice
+                    value: some-value-slice
+                  - key: some-other-key-slice
+                    value: some-other-value-slice
     asserts:
       - documentIndex: &ingressDoc 2
         isKind:
@@ -165,6 +184,18 @@ tests:
         equal:
           path: metadata.namespace
           value: test-release-namespace
+      - documentIndex: &fourthIngressDoc 5
+        isKind:
+          of: Ingress
+      - documentIndex: *fourthIngressDoc
+        equal:
+          path: metadata.annotations
+          value:
+            gethomepage.dev/enabled: "true"
+            gethomepage.dev/name: TestReleaseName
+            gethomepage.dev/description: Helper chart to test different use cases of the common library
+            gethomepage.dev/href: https://test-host/test-path
+            gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
 
   # Failures
   - it: should fail with podSelector not a slice

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 16.2.23
+version: 16.2.24

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -8,6 +8,11 @@
       {{- $_ := set $objectData.integrations.homepage "widget" dict -}}
     {{- end -}}
 
+    {{- $widEnabled := true -}}
+    {{- if (hasKey $homepage.widget "enabled") -}}
+      {{- $widEnabled = $homepage.widget.enabled -}}
+    {{- end -}}
+
     {{- include "tc.v1.common.lib.ingress.integration.homepage.validation" (dict "objectData" $objectData) -}}
 
     {{- $name := $homepage.name | default ($rootCtx.Release.Name | camelcase) -}}
@@ -43,7 +48,6 @@
     {{- $_ := set $objectData.annotations "gethomepage.dev/href" (tpl $href $rootCtx) -}}
     {{- $_ := set $objectData.annotations "gethomepage.dev/description" (tpl $desc $rootCtx) -}}
     {{- $_ := set $objectData.annotations "gethomepage.dev/icon" (tpl $icon $rootCtx) -}}
-    {{- $_ := set $objectData.annotations "gethomepage.dev/widget.type" (tpl $type $rootCtx) -}}
     {{- with $homepage.group -}}
       {{- $_ := set $objectData.annotations "gethomepage.dev/group" (tpl . $rootCtx) -}}
     {{- end -}}
@@ -51,23 +55,27 @@
     {{- with $homepage.weight -}}
       {{- $_ := set $objectData.annotations "gethomepage.dev/weight" (. | toString) -}}
     {{- end -}}
-
-    {{- with $url -}}
-      {{- $_ := set $objectData.annotations "gethomepage.dev/widget.url" (tpl $url $rootCtx) -}}
-    {{- end -}}
-
-    {{- if $homepage.widget.custom -}}
-      {{- range $k, $v := $homepage.widget.custom -}}
-        {{- $_ := set $objectData.annotations (printf "gethomepage.dev/widget.%s" $k) (tpl $v $rootCtx | toString) -}}
-      {{- end -}}
-      {{- range $homepage.widget.customkv -}}
-        {{- $_ := set $objectData.annotations (printf "gethomepage.dev/widget.%s" .key ) (tpl .value $rootCtx | toString) -}}
-      {{- end -}}
-    {{- end -}}
-
     {{- with $homepage.podSelector -}}
       {{- $selector := (printf "pod.name in (%s)" (join "," .)) -}}
       {{- $_ := set $objectData.annotations "gethomepage.dev/pod-selector" $selector -}}
+    {{- end -}}
+
+    {{- if $widEnabled -}}
+      {{- $_ := set $objectData.annotations "gethomepage.dev/widget.type" (tpl $type $rootCtx) -}}
+
+      {{- with $url -}}
+        {{- $_ := set $objectData.annotations "gethomepage.dev/widget.url" (tpl $url $rootCtx) -}}
+      {{- end -}}
+
+      {{- if $homepage.widget.custom -}}
+        {{- range $k, $v := $homepage.widget.custom -}}
+          {{- $_ := set $objectData.annotations (printf "gethomepage.dev/widget.%s" $k) (tpl $v $rootCtx | toString) -}}
+        {{- end -}}
+        {{- range $homepage.widget.customkv -}}
+          {{- $_ := set $objectData.annotations (printf "gethomepage.dev/widget.%s" .key ) (tpl .value $rootCtx | toString) -}}
+        {{- end -}}
+      {{- end -}}
+
     {{- end -}}
 
   {{- end -}}

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -9,7 +9,7 @@
     {{- end -}}
 
     {{- $widEnabled := true -}}
-    {{- if and (hasKey $homepage.widget "enabled") (kindIs "bool" $homepage.widget) -}}
+    {{- if and (hasKey $homepage.widget "enabled") (kindIs "bool" $homepage.widget.enabled) -}}
       {{- $widEnabled = $homepage.widget.enabled -}}
     {{- end -}}
 

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -9,7 +9,7 @@
     {{- end -}}
 
     {{- $widEnabled := true -}}
-    {{- if (hasKey $homepage.widget "enabled") -}}
+    {{- if and (hasKey $homepage.widget "enabled") (kindIs "bool" $homepage.widget) -}}
       {{- $widEnabled = $homepage.widget.enabled -}}
     {{- end -}}
 


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  https://github.com/truecharts/library-charts/issues/653

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
