### PR TITLE
fix(homepage): fix default selector

### DIFF
--- a/library/common-test/tests/ingress/homepage_test.yaml
+++ b/library/common-test/tests/ingress/homepage_test.yaml
@@ -125,7 +125,7 @@ tests:
             gethomepage.dev/widget.url: https://test-release-name-common-test.test-release-namespace.svc:9443
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
             gethomepage.dev/widget.type: commontest
-            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
+            gethomepage.dev/pod-selector: app.kubernetes.io/instance=test-release-name
       - documentIndex: *ingressDoc
         equal:
           path: metadata.name
@@ -177,7 +177,7 @@ tests:
             gethomepage.dev/widget.url: http://test-release-name-common-test-my-service2.test-release-namespace.svc:80
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
             gethomepage.dev/widget.type: commontest
-            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
+            gethomepage.dev/pod-selector: app.kubernetes.io/instance=test-release-name
       - documentIndex: *thirdIngressDoc
         equal:
           path: metadata.name
@@ -198,7 +198,7 @@ tests:
             gethomepage.dev/description: Helper chart to test different use cases of the common library
             gethomepage.dev/href: https://test-host/test-path
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
-            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
+            gethomepage.dev/pod-selector: app.kubernetes.io/instance=test-release-name
 
   # Failures
   - it: should fail with podSelector not a slice

--- a/library/common-test/tests/ingress/homepage_test.yaml
+++ b/library/common-test/tests/ingress/homepage_test.yaml
@@ -125,6 +125,7 @@ tests:
             gethomepage.dev/widget.url: https://test-release-name-common-test.test-release-namespace.svc:9443
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
             gethomepage.dev/widget.type: commontest
+            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
       - documentIndex: *ingressDoc
         equal:
           path: metadata.name
@@ -176,6 +177,7 @@ tests:
             gethomepage.dev/widget.url: http://test-release-name-common-test-my-service2.test-release-namespace.svc:80
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
             gethomepage.dev/widget.type: commontest
+            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
       - documentIndex: *thirdIngressDoc
         equal:
           path: metadata.name
@@ -196,6 +198,7 @@ tests:
             gethomepage.dev/description: Helper chart to test different use cases of the common library
             gethomepage.dev/href: https://test-host/test-path
             gethomepage.dev/icon: https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png
+            gethomepage.dev/pod-selector: app.kubernetes.io/name=common-test
 
   # Failures
   - it: should fail with podSelector not a slice

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 17.0.0
+version: 17.0.1

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -55,10 +55,12 @@
     {{- with $homepage.weight -}}
       {{- $_ := set $objectData.annotations "gethomepage.dev/weight" (. | toString) -}}
     {{- end -}}
+
+    {{- $selector := printf "app.kubernetes.io/name=%s" (include "tc.v1.common.lib.chart.names.name" $rootCtx) -}}
     {{- with $homepage.podSelector -}}
-      {{- $selector := (printf "pod.name in (%s)" (join "," .)) -}}
-      {{- $_ := set $objectData.annotations "gethomepage.dev/pod-selector" $selector -}}
+      {{- $selector = (printf "pod.name in (%s)" (join "," .)) -}}
     {{- end -}}
+    {{- $_ := set $objectData.annotations "gethomepage.dev/pod-selector" $selector -}}
 
     {{- if $widEnabled -}}
       {{- $_ := set $objectData.annotations "gethomepage.dev/widget.type" (tpl $type $rootCtx) -}}

--- a/library/common/templates/lib/ingress/integrations/_homepage.tpl
+++ b/library/common/templates/lib/ingress/integrations/_homepage.tpl
@@ -56,7 +56,7 @@
       {{- $_ := set $objectData.annotations "gethomepage.dev/weight" (. | toString) -}}
     {{- end -}}
 
-    {{- $selector := printf "app.kubernetes.io/name=%s" (include "tc.v1.common.lib.chart.names.name" $rootCtx) -}}
+    {{- $selector := printf "app.kubernetes.io/instance=%s" $rootCtx.Release.Name -}}
     {{- with $homepage.podSelector -}}
       {{- $selector = (printf "pod.name in (%s)" (join "," .)) -}}
     {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #655

By default when you dont set a selector, homepage uses the appName (from their config) as a selector.
We can set the correct selector there ourselves.
https://github.com/gethomepage/homepage/blob/4d6754e4a7258c46047d3cc2ca2e3fe63f6df76a/src/pages/api/kubernetes/status/%5B...service%5D.js#L19

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
