### PR TITLE
fix(velero): only process non-empty keys for config

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 17.1.2
+version: 17.1.3

--- a/library/common/templates/class/velero/_backupStorageLocation.tpl
+++ b/library/common/templates/class/velero/_backupStorageLocation.tpl
@@ -40,7 +40,9 @@ spec:
   {{- with $objectData.config }}
   config:
     {{- range $k, $v := . }}
+    {{- if $v -}}
     {{ $k }}: {{ tpl (toString $v) $rootCtx | quote }}
+    {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- with $objectData.backupSyncPeriod }}

--- a/library/common/templates/class/velero/_volumeSnapshotLocation.tpl
+++ b/library/common/templates/class/velero/_volumeSnapshotLocation.tpl
@@ -40,7 +40,9 @@ spec:
   {{- with $objectData.config }}
   config:
     {{- range $k, $v := . }}
+    {{- if $v -}}
     {{ $k }}: {{ tpl (toString $v) $rootCtx | quote }}
+    {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description**

Velero still does some validation on config keys, even if the value is empty.
This can cause into issues with invalid keys and such, which should be no issue when empty.

However, scale adds all keys, empty.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
