### PR TITLE
feat(common): allow adding velero schedule to individual charts

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~17.2.0
+  version: ~17.3.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/ci/schedule-values.yaml
+++ b/library/common-test/ci/schedule-values.yaml
@@ -40,7 +40,7 @@ manifestManager:
   enabled: false
 
 schedules:
-  - name:
+  test:
     enabled: true
     labels:
       myenv: foo
@@ -51,5 +51,3 @@ schedules:
     template:
       ttl: "240h"
       storageLocation: default
-      includedNamespaces:
-      - foo

--- a/library/common-test/ci/schedule-values.yaml
+++ b/library/common-test/ci/schedule-values.yaml
@@ -42,12 +42,4 @@ manifestManager:
 schedules:
   test:
     enabled: true
-    labels:
-      myenv: foo
-    annotations:
-      myenv: foo
     schedule: "0 0 * * *"
-    useOwnerReferencesInBackup: false
-    template:
-      ttl: "240h"
-      storageLocation: default

--- a/library/common-test/ci/schedule-values.yaml
+++ b/library/common-test/ci/schedule-values.yaml
@@ -54,3 +54,11 @@ schedules:
     template:
       ttl: "240h"
       storageLocation: default
+  test3:
+    enabled: true
+    schedule: "0 0 * * *"
+    template:
+      ttl: "240h"
+      storageLocation: default
+      includedNamespaces:
+      - foo

--- a/library/common-test/ci/schedule-values.yaml
+++ b/library/common-test/ci/schedule-values.yaml
@@ -43,3 +43,14 @@ schedules:
   test:
     enabled: true
     schedule: "0 0 * * *"
+  test2:
+    enabled: true
+    labels:
+      myenv: foo
+    annotations:
+      myenv: foo
+    schedule: "0 0 * * *"
+    useOwnerReferencesInBackup: false
+    template:
+      ttl: "240h"
+      storageLocation: default

--- a/library/common-test/tests/veleroSchedule/spec_test.yaml
+++ b/library/common-test/tests/veleroSchedule/spec_test.yaml
@@ -22,10 +22,10 @@ tests:
         equal:
           path: spec
           value:
-				    schedule: 0 2 * * *
-			    	template:
-				      includedNamespaces:
-				        - test-release-namespace
+                    schedule: 0 2 * * *
+                    template:
+                      includedNamespaces:
+                        - test-release-namespace
   - it: should generate correct spec with useOwnerReferencesInBackup
     set:
       schedules:
@@ -46,9 +46,9 @@ tests:
           value:
             schedule: "0 2 * * *"
             useOwnerReferencesInBackup: true
-			    	template:
-				      includedNamespaces:
-				        - test-release-namespace
+                    template:
+                      includedNamespaces:
+                        - test-release-namespace
 
   - it: should generate correct spec with template
     set:
@@ -76,8 +76,8 @@ tests:
               ttl: 720h
               includeClusterResources: true
               snapshotVolumes: true
-				      includedNamespaces:
-				        - test-release-namespace
+                      includedNamespaces:
+                        - test-release-namespace
 
   # Failures
   - it: should fail without schedule

--- a/library/common-test/tests/veleroSchedule/spec_test.yaml
+++ b/library/common-test/tests/veleroSchedule/spec_test.yaml
@@ -22,8 +22,10 @@ tests:
         equal:
           path: spec
           value:
-            schedule: "0 2 * * *"
-
+				    schedule: 0 2 * * *
+			    	template:
+				      includedNamespaces:
+				        - test-release-namespace
   - it: should generate correct spec with useOwnerReferencesInBackup
     set:
       schedules:
@@ -44,6 +46,9 @@ tests:
           value:
             schedule: "0 2 * * *"
             useOwnerReferencesInBackup: true
+			    	template:
+				      includedNamespaces:
+				        - test-release-namespace
 
   - it: should generate correct spec with template
     set:
@@ -71,6 +76,8 @@ tests:
               ttl: 720h
               includeClusterResources: true
               snapshotVolumes: true
+				      includedNamespaces:
+				        - test-release-namespace
 
   # Failures
   - it: should fail without schedule

--- a/library/common-test/tests/veleroSchedule/spec_test.yaml
+++ b/library/common-test/tests/veleroSchedule/spec_test.yaml
@@ -22,10 +22,10 @@ tests:
         equal:
           path: spec
           value:
-                    schedule: 0 2 * * *
-                    template:
-                      includedNamespaces:
-                        - test-release-namespace
+            schedule: 0 2 * * *
+            template:
+              includedNamespaces:
+                - test-release-namespace
   - it: should generate correct spec with useOwnerReferencesInBackup
     set:
       schedules:
@@ -46,9 +46,9 @@ tests:
           value:
             schedule: "0 2 * * *"
             useOwnerReferencesInBackup: true
-                    template:
-                      includedNamespaces:
-                        - test-release-namespace
+            template:
+              includedNamespaces:
+                - test-release-namespace
 
   - it: should generate correct spec with template
     set:
@@ -76,8 +76,8 @@ tests:
               ttl: 720h
               includeClusterResources: true
               snapshotVolumes: true
-                      includedNamespaces:
-                        - test-release-namespace
+              includedNamespaces:
+                - test-release-namespace
 
   # Failures
   - it: should fail without schedule

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 17.2.31
+version: 17.3.0

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -14,14 +14,14 @@ objectData:
 
   {{- $rootCtx := .rootCtx -}}
   {{- $objectData := .objectData }}
-  {{- $namespace := ( include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule" )) -}}
+  {{- $namespace := (include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule")) -}}
   {{- $lookupBSL := (lookup "velero.io/v1" "BackupStorageLocation" "" "") -}}
   {{- if and $lookupBSL $lookupBSL.items -}}
       {{- $lookupBSL = $lookupBSL.items  -}}
   {{- end -}}
   {{- range $BSL := $lookupBSL -}}
     {{- $namespace = $BSL.metadata.namespace -}}
-  {{- end -}}
+  {{- end }}
 ---
 apiVersion: velero.io/v1
 kind: Schedule

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -42,7 +42,7 @@ spec:
   schedule: {{ $objectData.schedule | quote }}
   {{- if (kindIs "bool" $objectData.useOwnerReferencesInBackup) }}
   useOwnerReferencesInBackup: {{ $objectData.useOwnerReferencesInBackup }}
-  {{- end -}}
+  {{- end }}
   template:
     {{- if not $objectData.template -}}
     includedNamespaces:

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -44,7 +44,7 @@ spec:
   useOwnerReferencesInBackup: {{ $objectData.useOwnerReferencesInBackup }}
   {{- end }}
   template:
-    {{- if not $objectData.template -}}
+    {{- if not $objectData.template }}
     includedNamespaces:
       - {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule") }}
     {{- end -}}

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -53,5 +53,4 @@ spec:
     {{- with $objectData.template }}
     {{- toYaml . | nindent 4 }}
     {{- end -}}
-  {{- end -}}
 {{- end -}}

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -14,7 +14,7 @@ objectData:
 
   {{- $rootCtx := .rootCtx -}}
   {{- $objectData := .objectData }}
-  {{- $namespace := ( include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule" ) -}}
+  {{- $namespace := ( include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule" )) -}}
   {{- $lookupBSL := (lookup "velero.io/v1" "BackupStorageLocation" "" "") -}}
   {{- if and $lookupBSL $lookupBSL.items -}}
     {{- with (index $lookupBSL.items 0) }}

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -46,11 +46,15 @@ spec:
   useOwnerReferencesInBackup: {{ $objectData.useOwnerReferencesInBackup }}
   {{- end -}}
   template:
-    {{- if or ( not $objectData.template ) ( and ( not $objectData.template ) ( not $objectData.template.includedNamespaces ) ) -}}
+    {{- if not $objectData.template -}}
     includedNamespaces:
       - {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule") }}
     {{- end -}}
     {{- with $objectData.template }}
     {{- toYaml . | nindent 4 }}
+    {{- if not .includedNamespaces }}
+    includedNamespaces:
+      - {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule") }}
+    {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -17,12 +17,10 @@ objectData:
   {{- $namespace := ( include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Schedule" )) -}}
   {{- $lookupBSL := (lookup "velero.io/v1" "BackupStorageLocation" "" "") -}}
   {{- if and $lookupBSL $lookupBSL.items -}}
-    {{- with (index $lookupBSL.items 0) }}
-      {{- $lookupBSL = . -}}
-    {{- end }}
+      {{- $lookupBSL = $lookupBSL.items  -}}
   {{- end -}}
-  {{- if $lookupBSL -}}
-    {{- $namespace = $lookupBSL.metadata.namespace -}}
+  {{- with (index $lookupBSL 0) }}
+    {{- $namespace = .metadata.namespace -}}
   {{- end -}}
 ---
 apiVersion: velero.io/v1

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -19,7 +19,7 @@ objectData:
   {{- if and $lookupBSL $lookupBSL.items -}}
       {{- $lookupBSL = $lookupBSL.items  -}}
   {{- end -}}
-  {{- with (index $lookupBSL 0) }}
+  {{- with ( index $lookupBSL ( $lookupBSL | keys | first ) ) }}
     {{- $namespace = .metadata.namespace -}}
   {{- end -}}
 ---

--- a/library/common/templates/class/velero/_schedule.tpl
+++ b/library/common/templates/class/velero/_schedule.tpl
@@ -19,8 +19,8 @@ objectData:
   {{- if and $lookupBSL $lookupBSL.items -}}
       {{- $lookupBSL = $lookupBSL.items  -}}
   {{- end -}}
-  {{- with ( index $lookupBSL ( $lookupBSL | keys | first ) ) }}
-    {{- $namespace = .metadata.namespace -}}
+  {{- range $BSL := $lookupBSL -}}
+    {{- $namespace = $BSL.metadata.namespace -}}
   {{- end -}}
 ---
 apiVersion: velero.io/v1

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -826,11 +826,10 @@ schedules: {}
 #       myenv: foo
 #     schedule: "0 0 * * *"
 #     useOwnerReferencesInBackup: false
+#     ## Included namespace, is set by default to the chart itself, unless explicitly specified
 #     template:
 #       ttl: "240h"
 #       storageLocation: default
-#       includedNamespaces:
-#       - foo
 # # -- create volumeSnapshotClass on demand
 # volumeSnapshotClass:
 #   example:


### PR DESCRIPTION
**Description**
After some discussion, we would prefer to have users setup velero schedules on a per-chart basis, besides any options available on the velero chart itself.

However the schedules need to be installed inside the velero namespace, while the included namespace, should (by default) be limited to the chart itself

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
