### PR TITLE
fix(common): allow kubernetes.io/service-account-token secrets to not have data

### DIFF
--- a/library/common-test/tests/secret/data_test.yaml
+++ b/library/common-test/tests/secret/data_test.yaml
@@ -112,3 +112,15 @@ tests:
             foo: |
               Some other text
               some_text
+
+  - it: should pass with empty data on kubernetes.io/service-account-token
+    set:
+      secret:
+        my-secret:
+          enabled: true
+          type: kubernetes.io/service-account-token
+    asserts:
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value: null

--- a/library/common-test/tests/secret/data_test.yaml
+++ b/library/common-test/tests/secret/data_test.yaml
@@ -113,7 +113,7 @@ tests:
               Some other text
               some_text
 
-  - it: should pass with empty data on kubernetes.io/service-account-token
+  - it: should pass with empty data on kubernetes.io/service-account-token type
     set:
       secret:
         my-secret:

--- a/library/common-test/tests/secret/validation_test.yaml
+++ b/library/common-test/tests/secret/validation_test.yaml
@@ -96,7 +96,7 @@ tests:
           data: {}
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Expected non-empty [data] or [stringData]
+          errorMessage: Secret - Expected non-empty [data]
 
   - it: should fail with empty type key
     set:
@@ -108,7 +108,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorMessage: Secret - Found [type] key, but it's empty
+          errorMessage: Secret - Expected non-empty [type] key
 
   - it: should fail with empty enabled
     set:
@@ -120,3 +120,14 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: Secret - Expected the defined key [enabled] in [secret.my-secret] to not be empty
+
+  - it: should fail with stringData usage
+    set:
+      secret:
+        my-secret:
+          enabled: true
+          stringData:
+            foo: bar
+    asserts:
+      - failedTemplate:
+          errorMessage: Secret - Key [stringData] is not supported

--- a/library/common/templates/lib/secret/_validation.tpl
+++ b/library/common/templates/lib/secret/_validation.tpl
@@ -10,16 +10,19 @@ objectData:
 {{- define "tc.v1.common.lib.secret.validation" -}}
   {{- $objectData := .objectData -}}
 
-  {{- if and ( not $objectData.data ) ( not $objectData.stringData ) -}}
-    {{- fail "Secret - Expected non-empty [data] or [stringData]" -}}
-  {{- end -}}
 
-  {{- if and $objectData.data (not (kindIs "map" $objectData.data)) -}}
-    {{- fail (printf "Secret - Expected [data] to be a dictionary, but got [%v]" (kindOf $objectData.data)) -}}
-  {{- end -}}
+  {{- if ne $objectData.type "kubernetes.io/service-account-token" -}}
+    {{- if and ( not $objectData.data ) ( not $objectData.stringData ) -}}
+      {{- fail "Secret - Expected non-empty [data] or [stringData]" -}}
+    {{- end -}}
 
-  {{- if and (hasKey $objectData "type") (not $objectData.type) -}}
-    {{- fail (printf "Secret - Found [type] key, but it's empty") -}}
+    {{- if and $objectData.data (not (kindIs "map" $objectData.data)) -}}
+      {{- fail (printf "Secret - Expected [data] to be a dictionary, but got [%v]" (kindOf $objectData.data)) -}}
+    {{- end -}}
+
+    {{- if and (hasKey $objectData "type") (not $objectData.type) -}}
+      {{- fail (printf "Secret - Found [type] key, but it's empty") -}}
+    {{- end -}}
   {{- end -}}
 
 {{- end -}}

--- a/library/common/templates/lib/secret/_validation.tpl
+++ b/library/common/templates/lib/secret/_validation.tpl
@@ -10,10 +10,13 @@ objectData:
 {{- define "tc.v1.common.lib.secret.validation" -}}
   {{- $objectData := .objectData -}}
 
+  {{- if $objectData.stringData -}}
+    {{- fail "Secret - Key [stringData] is not supported" -}}
+  {{- end -}}
 
   {{- if ne $objectData.type "kubernetes.io/service-account-token" -}}
-    {{- if and ( not $objectData.data ) ( not $objectData.stringData ) -}}
-      {{- fail "Secret - Expected non-empty [data] or [stringData]" -}}
+    {{- if and (not $objectData.data) -}}
+      {{- fail "Secret - Expected non-empty [data]" -}}
     {{- end -}}
 
     {{- if and $objectData.data (not (kindIs "map" $objectData.data)) -}}
@@ -21,7 +24,7 @@ objectData:
     {{- end -}}
 
     {{- if and (hasKey $objectData "type") (not $objectData.type) -}}
-      {{- fail (printf "Secret - Found [type] key, but it's empty") -}}
+      {{- fail (printf "Secret - Expected non-empty [type] key") -}}
     {{- end -}}
   {{- end -}}
 


### PR DESCRIPTION
**Description**
These will likely get created with the goal of the kube-system adding data. Not us

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
