### PR TITLE
feat(common): allow nvidia runtimeclass outside of scaleGPU on SCALE

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~17.4.0
+  version: ~17.5.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/tests/container/envFixed_test .yaml
+++ b/library/common-test/tests/container/envFixed_test .yaml
@@ -48,6 +48,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: S6_READ_ONLY_ROOT
                 value: "1"
 
@@ -90,6 +92,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: PUID
                 value: "568"
               - name: USER_ID
@@ -146,6 +150,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: PUID
                 value: "568"
               - name: USER_ID
@@ -201,6 +207,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: PUID
                 value: "568"
               - name: USER_ID
@@ -354,6 +362,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: PUID
                 value: "0"
               - name: USER_ID
@@ -452,6 +462,8 @@ tests:
                 value: "0022"
               - name: UMASK_SET
                 value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: PUID
                 value: "200000514"
               - name: USER_ID
@@ -464,6 +476,107 @@ tests:
                 value: "100000514"
               - name: GID
                 value: "100000514"
+              - name: S6_READ_ONLY_ROOT
+                value: "1"
+
+  - it: should create correct fixEnvs with nvidia.com/gpu in top level resources
+    set:
+      image: *image
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+      workload:
+        workload-name:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              container-name1:
+                enabled: true
+                primary: true
+                imageSelector: image
+                probes: *probes
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        isAPIVersion:
+          of: apps/v1
+      - documentIndex: *deploymentDoc
+        isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            env:
+              - name: TZ
+                value: UTC
+              - name: UMASK
+                value: "0022"
+              - name: UMASK_SET
+                value: "0022"
+              - name: NVIDIA_DRIVER_CAPABILITIES
+                value: all
+              - name: S6_READ_ONLY_ROOT
+                value: "1"
+
+  - it: should create correct fixEnvs with nvidia.com/gpu in container level resources
+    set:
+      image: *image
+      workload:
+        workload-name:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              container-name1:
+                enabled: true
+                primary: true
+                imageSelector: image
+                probes: *probes
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+              container-name2:
+                enabled: true
+                imageSelector: image
+                probes: *probes
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        isAPIVersion:
+          of: apps/v1
+      - documentIndex: *deploymentDoc
+        isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            env:
+              - name: TZ
+                value: UTC
+              - name: UMASK
+                value: "0022"
+              - name: UMASK_SET
+                value: "0022"
+              - name: NVIDIA_DRIVER_CAPABILITIES
+                value: all
+              - name: S6_READ_ONLY_ROOT
+                value: "1"
+      - documentIndex: *deploymentDoc
+        isSubset:
+          path: spec.template.spec.containers[1]
+          content:
+            env:
+              - name: TZ
+                value: UTC
+              - name: UMASK
+                value: "0022"
+              - name: UMASK_SET
+                value: "0022"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: void
               - name: S6_READ_ONLY_ROOT
                 value: "1"
 

--- a/library/common-test/tests/container/resources_test.yaml
+++ b/library/common-test/tests/container/resources_test.yaml
@@ -67,6 +67,8 @@ tests:
                   limits:
                     cpu: 2000m
                     memory: 4Gi
+                    some-resource: 1
+                    some-other-resource: 0
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -82,6 +84,53 @@ tests:
               limits:
                 cpu: 2000m
                 memory: 4Gi
+                some-resource: 1
+                some-other-resource: 0
+              requests:
+                cpu: 10m
+                memory: 50Mi
+
+  - it: should override the default limits from top level
+    set:
+      image: *image
+      resources:
+        limits:
+          some-resource: 1
+          some-other-resource: 0
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              container-name1:
+                enabled: true
+                primary: true
+                imageSelector: image
+                probes: *probes
+                resources:
+                  limits:
+                    cpu: 2000m
+                    memory: 4Gi
+                    some-resource: 2
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        isAPIVersion:
+          of: apps/v1
+      - documentIndex: *deploymentDoc
+        isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+                some-resource: 2
+                some-other-resource: 0
               requests:
                 cpu: 10m
                 memory: 50Mi

--- a/library/common-test/tests/initContainer/data_test.yaml
+++ b/library/common-test/tests/initContainer/data_test.yaml
@@ -138,6 +138,8 @@ tests:
                 value: "0022"
               - name: "UMASK_SET"
                 value: "0022"
+              - name: "NVIDIA_VISIBLE_DEVICES"
+                value: "void"
               - name: "S6_READ_ONLY_ROOT"
                 value: "1"
               - name: "key"

--- a/library/common-test/tests/initContainer/data_upgrade_test.yaml
+++ b/library/common-test/tests/initContainer/data_upgrade_test.yaml
@@ -142,6 +142,8 @@ tests:
                 value: "0022"
               - name: "UMASK_SET"
                 value: "0022"
+              - name: "NVIDIA_VISIBLE_DEVICES"
+                value: "void"
               - name: "S6_READ_ONLY_ROOT"
                 value: "1"
               - name: "key"

--- a/library/common-test/tests/pod/runtime_class_name_test.yaml
+++ b/library/common-test/tests/pod/runtime_class_name_test.yaml
@@ -216,3 +216,69 @@ tests:
         equal:
           path: spec.template.spec.runtimeClassName
           value: some-other-class
+
+  - it: should pass with runtimeClass set to nvidia when in SCALE and using the container "resources" directly
+    set:
+      global:
+        namespace: ix-namespace
+        ixChartContext:
+          addNvidiaRuntimeClass: true
+          nvidiaRuntimeClassName: ix-runtime
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              container-name:
+                enabled: true
+                primary: true
+                probes:
+                  liveness:
+                    enabled: false
+                  readiness:
+                    enabled: false
+                  startup:
+                    enabled: false
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+    asserts:
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.template.spec.runtimeClassName
+          value: nvidia
+
+  - it: should pass with runtimeClass set to nvidia when in SCALE and using the top level "resources" directly
+    set:
+      global:
+        namespace: ix-namespace
+        ixChartContext:
+          addNvidiaRuntimeClass: true
+          nvidiaRuntimeClassName: ix-runtime
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            containers:
+              container-name:
+                enabled: true
+                primary: true
+                probes:
+                  liveness:
+                    enabled: false
+                  readiness:
+                    enabled: false
+                  startup:
+                    enabled: false
+    asserts:
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.template.spec.runtimeClassName
+          value: nvidia

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 17.3.14
+version: 17.4.0
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/container/_resources.tpl
+++ b/library/common/templates/lib/container/_resources.tpl
@@ -28,6 +28,9 @@ limits:
   memory: {{ . }}
     {{- end -}}
     {{- include "tc.v1.common.lib.container.resources.gpu" (dict "rootCtx" $rootCtx "objectData" $objectData) | trim | nindent 2 -}}
+    {{- range $k, $v := (omit $resources.limits "cpu" "memory") }} {{/* Omit cpu and memory, as they are handled above */}}
+  {{ $k }}: {{ $v }}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/library/common/templates/lib/pod/_runtimeClassName.tpl
+++ b/library/common/templates/lib/pod/_runtimeClassName.tpl
@@ -22,17 +22,30 @@ objectData: The object data to be used to render the Pod.
 
   {{- if hasKey $rootCtx.Values.global "ixChartContext" -}}
     {{- if $rootCtx.Values.global.ixChartContext.addNvidiaRuntimeClass -}}
+    {{- $gpuAssigned := false -}}
+
+     {{- if gt $rootCtx.Values.resources.limits.nvidia.com/gpu "0" -}}
+       {{- $gpuAssigned = true -}}
+     {{- end -}}
+
+      {{- range $rootCtx.Values.workload -}}
+        {{- range $k, $v := .containers -}}
+          {{- if gt .resources.limits.nvidia.com/gpu "0" -}}
+            {{- $gpuAssigned = true -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
 
       {{- range $rootCtx.Values.scaleGPU -}}
         {{- if .gpu -}} {{/* Make sure it has a value... */}}
-          {{- $gpuAssigned := false -}}
-
+          
           {{- range $k, $v := .gpu -}}
             {{- if $v -}} {{/* Make sure value is not "0" or "" */}}
               {{- $gpuAssigned = true -}}
             {{- end -}}
           {{- end -}}
-
+        {{- end -}}
+      {{- end -}}
           {{- if $gpuAssigned -}}
             {{- if (kindIs "map" .targetSelector) -}}
               {{- range $podName, $containers := .targetSelector -}}
@@ -48,8 +61,7 @@ objectData: The object data to be used to render the Pod.
 
             {{- end -}}
           {{- end -}}
-        {{- end -}}
-      {{- end -}}
+
     {{- end -}}
   {{- end -}}
 

--- a/library/common/templates/lib/pod/_runtimeClassName.tpl
+++ b/library/common/templates/lib/pod/_runtimeClassName.tpl
@@ -20,48 +20,81 @@ objectData: The object data to be used to render the Pod.
     {{- $runtime = tpl . $rootCtx -}}
   {{- end -}}
 
+  {{/* If on SCALE... */}}
   {{- if hasKey $rootCtx.Values.global "ixChartContext" -}}
-    {{- if $rootCtx.Values.global.ixChartContext.addNvidiaRuntimeClass -}}
-    {{- $gpuAssigned := false -}}
+    {{- $r := include "tc.v1.common.lib.pod.runtimeClassName.scale" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+    {{- if $r -}}
+      {{- $runtime = $r -}}
+    {{- end -}}
+  {{- end -}}
 
-     {{- if gt $rootCtx.Values.resources.limits.nvidia.com/gpu "0" -}}
-       {{- $gpuAssigned = true -}}
-     {{- end -}}
+  {{- $runtime -}}
+{{- end -}}
 
-      {{- range $rootCtx.Values.workload -}}
-        {{- range $k, $v := .containers -}}
-          {{- if gt .resources.limits.nvidia.com/gpu "0" -}}
-            {{- $gpuAssigned = true -}}
-          {{- end -}}
-        {{- end -}}
+{{- define "tc.v1.common.lib.pod.runtimeClassName.scale" -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData -}}
+  {{- $runtime := "" -}}
+
+  {{- $nvidia := false -}}
+
+  {{- if and ($rootCtx.Values.resources) ($rootCtx.Values.resources.limits) -}}
+    {{- if gt ((get $rootCtx.Values.resources.limits "nvidia.com/gpu") | int) 0 -}}
+      {{- $nvidia = true -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range $rootCtx.Values.workload -}}
+    {{- if not .podSpec -}}
+      {{- continue -}}
+    {{- end -}}
+
+    {{- range $k, $v := .podSpec.containers -}}
+      {{- if or (not $v.resources) (not $v.resources.limits) -}}
+        {{- continue -}}
       {{- end -}}
 
-      {{- range $rootCtx.Values.scaleGPU -}}
-        {{- if .gpu -}} {{/* Make sure it has a value... */}}
-          
-          {{- range $k, $v := .gpu -}}
-            {{- if $v -}} {{/* Make sure value is not "0" or "" */}}
-              {{- $gpuAssigned = true -}}
-            {{- end -}}
+      {{- if gt ((get $v.resources.limits "nvidia.com/gpu") | int) 0 -}}
+        {{- $nvidia = true -}}
+        {{- break -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if $nvidia -}}
+    {{/* https://github.com/truenas/middleware/blob/0bfc05166c3f95b1ab4ca4a9614691f14303db2e/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py#L16 */}}
+    {{- $runtime = "nvidia" -}}
+  {{- end -}}
+
+  {{/* Keep backwards compat with .scaleGPU */}}
+  {{- if $rootCtx.Values.global.ixChartContext.addNvidiaRuntimeClass -}}
+    {{- range $rootCtx.Values.scaleGPU -}}
+      {{- if .gpu -}} {{/* Make sure it has a value... */}}
+        {{- $scaleGPU := false -}}
+        {{- range $k, $v := .gpu -}}
+          {{- if $v -}} {{/* Make sure value is not "0" or "" */}}
+            {{- $scaleGPU = true -}}
+            {{- break -}}
           {{- end -}}
         {{- end -}}
-      {{- end -}}
-          {{- if $gpuAssigned -}}
-            {{- if (kindIs "map" .targetSelector) -}}
-              {{- range $podName, $containers := .targetSelector -}}
-                {{- if eq $objectData.shortName $podName -}} {{/* If the pod is selected */}}
-                  {{- $runtime = $rootCtx.Values.global.ixChartContext.nvidiaRuntimeClassName -}}
-                {{- end -}}
+
+        {{- if $scaleGPU -}}
+
+          {{- if (kindIs "map" .targetSelector) -}}
+            {{- range $podName, $containers := .targetSelector -}}
+
+              {{- if eq $objectData.shortName $podName -}} {{/* If the pod is selected */}}
+                {{- $runtime = $rootCtx.Values.global.ixChartContext.nvidiaRuntimeClassName -}}
               {{- end -}}
 
-            {{- else if $objectData.primary -}}
-
-              {{/* If the pod is primary and no targetSelector is given, assign to primary */}}
-              {{- $runtime = $rootCtx.Values.global.ixChartContext.nvidiaRuntimeClassName -}}
-
             {{- end -}}
+          {{- else if $objectData.primary -}}
+            {{/* If the pod is primary and no targetSelector is given, assign to primary */}}
+            {{- $runtime = $rootCtx.Values.global.ixChartContext.nvidiaRuntimeClassName -}}
           {{- end -}}
 
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 


### PR DESCRIPTION
**Description**
This is an early draft to correctly set the runtimeClass name, when using nvidia GPU on SCALE, but without the SCALE GPU GUI.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
