### PR TITLE
feat(common): add support for projected Volumes

### DIFF
--- a/.github/workflows/common.release.yaml
+++ b/.github/workflows/common.release.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # tag=v3
       with:
-        version: v3.13.3
+        version: v3.14.1
 
     # Optional step if GPG signing is used
     - name: Prepare GPG key

--- a/.github/workflows/common_library_tests.yaml
+++ b/.github/workflows/common_library_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         helm-version:
           - v3.12.3
-          - v3.14.0
+          - v3.14.1
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -62,7 +62,7 @@ jobs:
       matrix:
         helm-version:
           - v3.12.3
-          - v3.14.0
+          - v3.14.1
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -110,7 +110,7 @@ jobs:
         # We run tests on Helm version of latest SCALE, fluxcd and latest helm release
         helm-version:
           - v3.12.3
-          - v3.14.0
+          - v3.14.1
         values:
           - basic-values.yaml
           - configmap-values.yaml

--- a/.github/workflows/common_library_tests.yaml
+++ b/.github/workflows/common_library_tests.yaml
@@ -200,10 +200,7 @@ jobs:
           tar -xvzf kail_${KAIL_VERSION}_linux_amd64.tar.gz
           chmod +x kail
 
-      - name: Prep Helm
-        run: |
-          helm repo add truecharts-deps https://deps.truecharts.org
-          helm repo update
+
 
       - name: Add Dependencies
         run: |
@@ -335,10 +332,7 @@ jobs:
 #        with:
 #          version: ${{ matrix.helm-version }}
 #
-#      - name: Prep Helm
-#        run: |
-#          helm repo add truecharts-deps https://deps.truecharts.org
-#          helm repo update
+
 #      - name: Add Dependencies
 #        run: |
 #            helm install prometheus-operator oci://tccr.io/truecharts/prometheus-operator --namespace prometheus-operator --create-namespace --wait

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~17.3.0
+  version: ~17.4.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 17.3.14
+version: 17.4.0
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/pod/_volumes.tpl
+++ b/library/common/templates/lib/pod/_volumes.tpl
@@ -67,6 +67,8 @@ objectData: The object data to be used to render the Pod.
           {{- include "tc.v1.common.lib.pod.volume.nfs" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- else if eq "iscsi" $type -}}
           {{- include "tc.v1.common.lib.pod.volume.iscsi" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
+        {{- else if eq "projected" $type -}}
+          {{- include "tc.v1.common.lib.pod.volume.projected" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- else if eq "device" $type -}}
           {{- include "tc.v1.common.lib.pod.volume.device" (dict "rootCtx" $rootCtx "objectData" $persistence) | trim | nindent 0 -}}
         {{- end -}}

--- a/library/common/templates/lib/pod/volumes/_projected.tpl
+++ b/library/common/templates/lib/pod/volumes/_projected.tpl
@@ -1,0 +1,70 @@
+{{/* Returns projected Volume */}}
+{{/* Call this template:
+{{ include "tc.v1.common.lib.pod.volume.projected" (dict "rootCtx" $ "objectData" $objectData) }}
+rootCtx: The root context of the chart.
+objectData: The object data to be used to render the volume.
+*/}}
+{{- define "tc.v1.common.lib.pod.volume.projected" -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $objectData := .objectData -}}
+
+  {{- if not $objectData.objectName -}}
+    {{- fail "Persistence - Expected non-empty [objectName] on [projected] type" -}}
+  {{- end -}}
+
+  {{- $objectName := tpl $objectData.objectName $rootCtx -}}
+
+  {{- $expandName := (include "tc.v1.common.lib.util.expandName" (dict
+                  "rootCtx" $rootCtx "objectData" $objectData
+                  "name" $objectData.shortName "caller" "projected"
+                  "key" "projected")) -}}
+
+  {{- if eq $expandName "true" -}}
+    {{- $object := (get $rootCtx.Values.projected $objectName) -}}
+    {{- if and (not $object) (not $objectData.optional) -}}
+      {{- fail (printf "Persistence - Expected projected [%s] defined in [objectName] to exist" $objectName) -}}
+    {{- end -}}
+
+    {{- $objectName = (printf "%s-%s" (include "tc.v1.common.lib.chart.names.fullname" $rootCtx) $objectName) -}}
+  {{- end -}}
+
+  {{- $optional := false -}}
+  {{- if hasKey $objectData "optional" -}}
+    {{- if not (kindIs "bool" $objectData.optional) -}}
+      {{- fail (printf "Persistence - Expected [optional] to be [bool], but got [%s]" (kindOf $objectData.optional)) -}}
+    {{- end -}}
+    {{- $optional = $objectData.optional -}}
+  {{- end -}}
+
+  {{- $defMode := "" -}}
+  {{- if (and $objectData.defaultMode (not (kindIs "string" $objectData.defaultMode))) -}}
+    {{- fail (printf "Persistence - Expected [defaultMode] to be [string], but got [%s]" (kindOf $objectData.defaultMode)) -}}
+  {{- end -}}
+
+  {{- with $objectData.defaultMode -}}
+    {{- $defMode = tpl $objectData.defaultMode $rootCtx -}}
+  {{- end -}}
+
+  {{- if and $defMode (not (mustRegexMatch "^[0-9]{4}$" $defMode)) -}}
+    {{- fail (printf "Persistence - Expected [defaultMode] to have be in format of [\"0777\"], but got [%q]" $defMode) -}}
+  {{- end }}
+- name: {{ $objectData.shortName }}
+  projected:
+    name: {{ $objectName }}
+    {{- with $defMode }}
+    defaultMode: {{ . }}
+    {{- end }}
+    {{- with $objectData.sources }}
+    sources:
+      {{- range . -}}
+        {{- range $k, $v := . -}}
+          {{- $allowedSources := list "clusterTrustBundle" "configMap" "downwardAPI" "secret" "serviceAccountToken" -}}
+          {{- if not (has $allowedSources $k) -}}
+            {{- fail "Persistence - Invalid source [$k] for projected Volume $objectName" -}}
+          {{- end -}}
+        {{ $k }}:
+          {{- tpl (toYaml $v) $rootCtx | nindent 10 }}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/library/common/templates/lib/pod/volumes/_projected.tpl
+++ b/library/common/templates/lib/pod/volumes/_projected.tpl
@@ -28,14 +28,6 @@ objectData: The object data to be used to render the volume.
     {{- $objectName = (printf "%s-%s" (include "tc.v1.common.lib.chart.names.fullname" $rootCtx) $objectName) -}}
   {{- end -}}
 
-  {{- $optional := false -}}
-  {{- if hasKey $objectData "optional" -}}
-    {{- if not (kindIs "bool" $objectData.optional) -}}
-      {{- fail (printf "Persistence - Expected [optional] to be [bool], but got [%s]" (kindOf $objectData.optional)) -}}
-    {{- end -}}
-    {{- $optional = $objectData.optional -}}
-  {{- end -}}
-
   {{- $defMode := "" -}}
   {{- if (and $objectData.defaultMode (not (kindIs "string" $objectData.defaultMode))) -}}
     {{- fail (printf "Persistence - Expected [defaultMode] to be [string], but got [%s]" (kindOf $objectData.defaultMode)) -}}


### PR DESCRIPTION
**Description**
Current common does not support projected volumes.
Which we need to mount serviceaccounttokens as files for https://github.com/truecharts/charts/pull/18259

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
