### PR TITLE
chore(common): change order of initdb init application sql

### DIFF
--- a/library/common-test/tests/cnpg/cluster_spec_test.yaml
+++ b/library/common-test/tests/cnpg/cluster_spec_test.yaml
@@ -382,8 +382,8 @@ tests:
                 owner: app
                 dataChecksums: true
                 postInitApplicationSQL:
-                  - CREATE EXTENSION IF NOT EXISTS some-extension;
                   - CREATE EXTENSION IF NOT EXISTS timescaledb;
+                  - CREATE EXTENSION IF NOT EXISTS some-extension;
 
   - it: should pass with enabled monitoring
     set:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.0.6
+version: 20.0.7
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/cnpg/cluster/_bootstrapStandalone.tpl
+++ b/library/common/templates/lib/cnpg/cluster/_bootstrapStandalone.tpl
@@ -11,12 +11,6 @@
     {{- $_ := set $objectData.cluster "initdb" dict -}}
   {{- end -}}
 
-  {{- if $objectData.cluster.initdb -}}
-    {{- $postInitApplicationSQL = $objectData.cluster.initdb.postInitApplicationSQL | default list -}}
-    {{- $postInitSQL = $objectData.cluster.initdb.postInitSQL | default list -}}
-    {{- $postInitTemplateSQL = $objectData.cluster.initdb.postInitTemplateSQL | default list -}}
-  {{- end -}}
-
   {{- if (kindIs "bool" $objectData.cluster.initdb.dataChecksums) -}}
     {{- $dataChecksums = $objectData.cluster.initdb.dataChecksums -}}
   {{- end -}}
@@ -36,7 +30,14 @@
 
   {{- if eq $objectData.type "vectors" -}}
     {{- $postInitApplicationSQL = concat $postInitApplicationSQL (list
-      "CREATE EXTENSION IF NOT EXISTS vectors;") -}}
+      "CREATE EXTENSION IF NOT EXISTS vectors;"
+      "GRANT SELECT ON TABLE pg_vector_index_stat TO PUBLIC;") -}}
+  {{- end -}}
+
+  {{- if $objectData.cluster.initdb -}}
+    {{- $postInitApplicationSQL = concat $postInitApplicationSQL ( $objectData.cluster.initdb.postInitApplicationSQL | default list ) -}}
+    {{- $postInitSQL = concat $postInitSQL ( $objectData.cluster.initdb.postInitSQL | default list ) -}}
+    {{- $postInitTemplateSQL = concat $postInitTemplateSQL ( $objectData.cluster.initdb.postInitTemplateSQL | default list ) -}}
   {{- end -}}
 
 initdb:


### PR DESCRIPTION
**Description**

We should set custom initdb sql, AFTER we've enabled extentions, otherwise we cannot run this SQL over extention specific codepaths

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
