### PR TITLE
feat(common): add a temporary failsafe to filter dragonfish and cobia SCALE users that forgot to follow instructions

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~20.1.0
+  version: ~20.2.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~21.0.0
+  version: ~20.2.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: ""
 dependencies:
 - name: common
   repository: file://../common
-  version: ~20.2.0
+  version: ~21.0.0
 deprecated: false
 description: Helper chart to test different use cases of the common library
 home: https://github.com/truecharts/apps/tree/master/charts/library/common-test

--- a/library/common-test/tests/persistence/pvc_data_test.yaml
+++ b/library/common-test/tests/persistence/pvc_data_test.yaml
@@ -202,6 +202,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ix-storage-class-releasename
+          ci:
+            storageClass: true
       some_storage_class: "SCALE-ZFS"
       persistence:
         my-volume1:

--- a/library/common-test/tests/persistence/validation_test.yaml
+++ b/library/common-test/tests/persistence/validation_test.yaml
@@ -62,6 +62,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ""
+          ci:
+            storageClass: true
       persistence:
         volume1:
           enabled: true

--- a/library/common-test/tests/persistence/validation_test.yaml
+++ b/library/common-test/tests/persistence/validation_test.yaml
@@ -56,22 +56,6 @@ tests:
       - failedTemplate:
           errorMessage: PVC - Expected [accessModes] entry to be one of [ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod], but got [not-an-access-mode]
 
-  - it: should fail without storageClassName in ixChartContext
-    set:
-      global:
-        namespace: ix-namespace
-        ixChartContext:
-          storageClassName: ""
-          ci:
-            storageClass: true
-      persistence:
-        volume1:
-          enabled: true
-          type: pvc
-    asserts:
-      - failedTemplate:
-          errorMessage: PVC - Expected non-empty [global.ixChartContext.storageClassName]
-
   - it: should fail without storageClassName in ixChartContext with SCALE-ZFS explicitly set
     set:
       global:

--- a/library/common-test/tests/persistence/validation_test.yaml
+++ b/library/common-test/tests/persistence/validation_test.yaml
@@ -78,6 +78,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ""
+          ci:
+            storageClass: true
       persistence:
         volume1:
           enabled: true

--- a/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
@@ -62,6 +62,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ""
+          ci:
+            storageClass: true
       persistence:
         volume1:
           enabled: true

--- a/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
@@ -84,6 +84,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ""
+          ci:
+            storageClass: true
       persistence:
         volume1:
           enabled: true

--- a/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/validation_test.yaml
@@ -56,28 +56,6 @@ tests:
       - failedTemplate:
           errorMessage: Persistence - Expected [targetSelector] to be [dict], but got [string]
 
-  - it: should fail without storageClassName in ixChartContext
-    set:
-      global:
-        namespace: ix-namespace
-        ixChartContext:
-          storageClassName: ""
-          ci:
-            storageClass: true
-      persistence:
-        volume1:
-          enabled: true
-          type: vct
-      workload:
-        main:
-          enabled: true
-          primary: true
-          type: StatefulSet
-          podSpec: {}
-    asserts:
-      - failedTemplate:
-          errorMessage: PVC - Expected non-empty [global.ixChartContext.storageClassName]
-
   - it: should fail without storageClassName in ixChartContext with SCALE-ZFS explicitly set
     set:
       global:

--- a/library/common-test/tests/volumeClaimTemplate/vct_data_test.yaml
+++ b/library/common-test/tests/volumeClaimTemplate/vct_data_test.yaml
@@ -278,6 +278,8 @@ tests:
         namespace: ix-namespace
         ixChartContext:
           storageClassName: ix-storage-class-releasename
+          ci:
+            storageClass: true
       some_storage_class: "SCALE-ZFS"
       persistence:
         my-volume1:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.1.2
+version: 20.2.0
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.2.0
+version: 21.0.0
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 21.0.0
+version: 20.2.0
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/storage/_storageClassName.tpl
+++ b/library/common/templates/lib/storage/_storageClassName.tpl
@@ -37,11 +37,20 @@ objectData: The object data of the pvc
       {{- $className = tpl $storageClass $rootCtx -}}
     {{- end -}}
 
-  {{- else if $rootCtx.Values.global.ixChartContext -}}
-    {{- if not $rootCtx.Values.global.ixChartContext.storageClassName -}}
-      {{- fail (printf "%s - Expected non-empty [global.ixChartContext.storageClassName]" $caller) -}}
+  {{- else if and $rootCtx.Values.global.ixChartContext $rootCtx.Values.global.ixChartContext.storageClassName -}}
+    {{- $scaleClassFound := false -}}
+    {{- with (lookup "v1" "StorageClass" "" $rootCtx.Values.global.ixChartContext.storageClassName ) -}}
+      {{/* Check if there is an actually valid storageClass found */}}
+      {{- if .provisioner -}}
+        {{- $scaleClassFound = true -}}
+      {{- end -}}
     {{- end -}}
-    {{- $className = tpl $rootCtx.Values.global.ixChartContext.storageClassName $rootCtx -}}
+
+    {{- if or $scaleClassFound $rootCtx.Values.global.ixChartContext.ci.storageClass -}}
+      {{- $className = tpl $rootCtx.Values.global.ixChartContext.storageClassName $rootCtx -}}
+    {{- else if $rootCtx.Values.global.fallbackDefaults.storageClass -}}
+      {{- $className = tpl $rootCtx.Values.global.fallbackDefaults.storageClass $rootCtx -}}
+    {{- end -}}
 
   {{- else if $rootCtx.Values.global.fallbackDefaults.storageClass -}}
 

--- a/library/common/templates/lib/storage/_storageClassName.tpl
+++ b/library/common/templates/lib/storage/_storageClassName.tpl
@@ -46,7 +46,7 @@ objectData: The object data of the pvc
       {{- end -}}
     {{- end -}}
 
-    {{- if or $scaleClassFound $rootCtx.Values.global.ixChartContext.ci.storageClass -}}
+    {{- if or $scaleClassFound ( and $rootCtx.Values.global.ixChartContext.ci $rootCtx.Values.global.ixChartContext.ci.storageClass) -}}
       {{- $className = tpl $rootCtx.Values.global.ixChartContext.storageClassName $rootCtx -}}
     {{- else if $rootCtx.Values.global.fallbackDefaults.storageClass -}}
       {{- $className = tpl $rootCtx.Values.global.fallbackDefaults.storageClass $rootCtx -}}

--- a/library/common/templates/lib/storage/_storageClassName.tpl
+++ b/library/common/templates/lib/storage/_storageClassName.tpl
@@ -37,16 +37,17 @@ objectData: The object data of the pvc
       {{- $className = tpl $storageClass $rootCtx -}}
     {{- end -}}
 
+  {{/* On Cobia -> Dragonfish update the ixChartContext should still be there, for existing apps so we can reference it */}}
   {{- else if and $rootCtx.Values.global.ixChartContext $rootCtx.Values.global.ixChartContext.storageClassName -}}
     {{- $scaleClassFound := false -}}
-    {{- with (lookup "v1" "StorageClass" "" $rootCtx.Values.global.ixChartContext.storageClassName ) -}}
+    {{- with (lookup "v1" "StorageClass" "" $rootCtx.Values.global.ixChartContext.storageClassName) -}}
       {{/* Check if there is an actually valid storageClass found */}}
       {{- if .provisioner -}}
         {{- $scaleClassFound = true -}}
       {{- end -}}
     {{- end -}}
 
-    {{- if or $scaleClassFound ( and $rootCtx.Values.global.ixChartContext.ci $rootCtx.Values.global.ixChartContext.ci.storageClass) -}}
+    {{- if or $scaleClassFound (and $rootCtx.Values.global.ixChartContext.ci $rootCtx.Values.global.ixChartContext.ci.storageClass) -}}
       {{- $className = tpl $rootCtx.Values.global.ixChartContext.storageClassName $rootCtx -}}
     {{- else if $rootCtx.Values.global.fallbackDefaults.storageClass -}}
       {{- $className = tpl $rootCtx.Values.global.fallbackDefaults.storageClass $rootCtx -}}


### PR DESCRIPTION
**Description**
This is a **TEMPORARY** hotfix to ensure SCALE users that forgot setting their `storageClass` to `SCALE-ZFS`, loose data on update to dragonfish.

This will be removed in the future, likely together with support for SCALE storageClasses all-together.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
