### PR TITLE
feat(common): prevent the use of `ix-` namespace prefix outside of SCALE-Apps

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.1.1
+version: 20.1.2
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/metadata/_namespace.tpl
+++ b/library/common/templates/lib/metadata/_namespace.tpl
@@ -28,6 +28,9 @@
         {{- fail (printf "%s - Namespace [%v] expected to have [ix-] prefix when installed in TrueNAS SCALE" $caller $namespace) -}}
       {{- end -}}
     {{- end -}}
+  {{- else if and (hasPrefix "ix-" $namespace) ( not $rootCtx.Values.global.ixChartContext ) -}}
+      {{/* Users should not use SCALE-reserved Namespace prefixes to hack things into the SCALE GUI */}}
+        {{- fail (printf "%s - Namespace [%v] is not allowed to have [ix-] prefix when installed outside of SCALE-Apps" $caller $namespace) -}}
   {{- end -}}
 
   {{- $namespace -}}


### PR DESCRIPTION
**Description**
Some users are fucking around trying to get kubeapps recognised by SCALE, this is PRECISELY what iX-Systems **and** TrueCharts do **NOT** want. As fucking around with this, **will** lead to inherent issues. Only to have people play dumb and file support tickets at either party

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
