### PR TITLE
fix(gluetun): add FIREWALL_INPUT_PORTS pointing to main service port

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.2.11
+version: 20.2.12
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -43,6 +43,7 @@ env:
 {{- end }}
   FIREWALL: "on"
   FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworks | quote }}
+  FIREWALL_INPUT_PORTS: {{ $.Values.service.main.ports.main.port }}
 {{- else }}
   FIREWALL: "off"
 {{- end }}


### PR DESCRIPTION
**Description**
Hello,

right now there is no default definition for FIREWALL_INPUT_PORTS which seem to be needed on helm/kubeapps deployment for healthcheck to work ([see gluetun wiki](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md)). I think if I did this right this will pull main service port from values.yaml and automatically open it on default interface for health check.

note: if service uses multiple ports, this likely wont work for all of them and user will need to manually set FIREWALL_INPUT_PORT themselves.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
i don't know how to test locally, i'm so sorry >.<;;

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
