### PR TITLE
feat(gluetun): add inputPorts & handle common usecase

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.2.13
+version: 20.2.14
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -46,7 +46,13 @@ env:
 {{- end }}
   FIREWALL: "on"
   FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworks | quote }}
-  FIREWALL_INPUT_PORTS: {{ $.Values.service.main.ports.main.port }}
+{{- $inputPorts = (list $.Values.service.main.ports.main.port) -}}
+{{/* if trying to use qbittorrent port forwarding, detect and add ports */}}
+{{- if $.Values.qbitportforward.enabled -}}
+  {{- $inputPorts = mustAppend ($inputPorts $.Values.service.gluetun.ports.gluetun.port) -}}
+{{- end -}}
+{{- $inputPorts = concat $inputPorts $.Values.addons.vpn.inputPorts | mustUniq }}
+  FIREWALL_INPUT_PORTS: {{ join "," $inputPorts }}
 {{- else }}
   FIREWALL: "off"
 {{- end }}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -46,10 +46,10 @@ env:
 {{- end }}
   FIREWALL: "on"
   FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworks | quote }}
-{{- $inputPorts = (list $.Values.service.main.ports.main.port) -}}
+{{- $inputPorts := (list $.Values.service.main.ports.main.port) -}}
 {{/* if trying to use qbittorrent port forwarding, detect and add ports */}}
 {{- if $.Values.qbitportforward.enabled -}}
-  {{- $inputPorts = mustAppend ($inputPorts $.Values.service.gluetun.ports.gluetun.port) -}}
+  {{- $inputPorts = mustAppend $inputPorts $.Values.service.gluetun.ports.gluetun.port -}}
 {{- end -}}
 {{- $inputPorts = concat $inputPorts $.Values.addons.vpn.inputPorts | mustUniq }}
   FIREWALL_INPUT_PORTS: {{ join "," $inputPorts }}

--- a/library/common/templates/addons/vpn/_gluetunContainer.tpl
+++ b/library/common/templates/addons/vpn/_gluetunContainer.tpl
@@ -47,10 +47,6 @@ env:
   FIREWALL: "on"
   FIREWALL_OUTBOUND_SUBNETS: {{ $excludednetworks | quote }}
 {{- $inputPorts := (list $.Values.service.main.ports.main.port) -}}
-{{/* if trying to use qbittorrent port forwarding, detect and add ports */}}
-{{- if $.Values.qbitportforward.enabled -}}
-  {{- $inputPorts = mustAppend $inputPorts $.Values.service.gluetun.ports.gluetun.port -}}
-{{- end -}}
 {{- $inputPorts = concat $inputPorts $.Values.addons.vpn.inputPorts | mustUniq }}
   FIREWALL_INPUT_PORTS: {{ join "," $inputPorts }}
 {{- else }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -1003,6 +1003,9 @@ addons:
     excludedNetworks_IPv4: []
     excludedNetworks_IPv6: []
 
+    ## For Gluetun to enable kubernetes network communication
+    inputPorts: []
+
   # -- The common library supports adding a code-server add-on to access files. It can be configured under this key.
   # @default -- See values.yaml
   codeserver:


### PR DESCRIPTION
**Description**
This implement idea by @stavros-k in #771 and also add logic to detect when user has enable qbitportforward, and automatically add gluetun control port to inputPorts as well. Thank you stavros for help!

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
