### PR TITLE
fix(common): improve probes

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 20.3.10
+version: 20.3.11
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/container/_probes.tpl
+++ b/library/common/templates/lib/container/_probes.tpl
@@ -85,6 +85,12 @@ objectData: The object data to be used to render the container.
     {{- end -}}
   {{- end -}}
 
+  {{- if mustHas $probeName (list "liveness" "startup") -}}
+    {{- if ne (int $timeouts.successThreshold) 1 -}}
+      {{- fail (printf "Container - Expected [probes] [successThreshold] to be 1 on [%s] probe" $probeName) -}}
+    {{- end -}}
+  {{- end }}
+
 initialDelaySeconds: {{ $timeouts.initialDelaySeconds }}
 failureThreshold: {{ $timeouts.failureThreshold }}
 successThreshold: {{ $timeouts.successThreshold }}

--- a/library/common/templates/lib/container/_probes.tpl
+++ b/library/common/templates/lib/container/_probes.tpl
@@ -85,11 +85,6 @@ objectData: The object data to be used to render the container.
     {{- end -}}
   {{- end -}}
 
-  {{- if mustHas $probeName (list "liveness" "startup") -}}
-    {{- if ne (int $timeouts.successThreshold) 1 -}}
-      {{- fail (printf "Container - Expected [probes] [successThreshold] to be 1 on [%s] probe" $probeName) -}}
-    {{- end -}}
-  {{- end }}
 initialDelaySeconds: {{ $timeouts.initialDelaySeconds }}
 failureThreshold: {{ $timeouts.failureThreshold }}
 successThreshold: {{ $timeouts.successThreshold }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -43,8 +43,8 @@ global:
         initialDelaySeconds: 20
         periodSeconds: 10
         timeoutSeconds: 5
-        failureThreshold: 3
-        successThreshold: 1
+        failureThreshold: 5
+        successThreshold: 2
       startup:
         initialDelaySeconds: 10
         periodSeconds: 5

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -34,16 +34,16 @@ global:
     # -- Default probe timeouts
     probeTimeouts:
       liveness:
-        initialDelaySeconds: 10
-        periodSeconds: 12
-        timeoutSeconds: 5
-        failureThreshold: 5
-        successThreshold: 1
-      readiness:
         initialDelaySeconds: 12
         periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 5
+        successThreshold: 1
+      readiness:
+        initialDelaySeconds: 10
+        periodSeconds: 12
+        timeoutSeconds: 5
+        failureThreshold: 4
         successThreshold: 2
       startup:
         initialDelaySeconds: 10

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -34,14 +34,14 @@ global:
     # -- Default probe timeouts
     probeTimeouts:
       liveness:
-        initialDelaySeconds: 20
-        periodSeconds: 15
+        initialDelaySeconds: 10
+        periodSeconds: 12
         timeoutSeconds: 5
         failureThreshold: 5
         successThreshold: 1
       readiness:
-        initialDelaySeconds: 20
-        periodSeconds: 10
+        initialDelaySeconds: 12
+        periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 5
         successThreshold: 2

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -34,21 +34,21 @@ global:
     # -- Default probe timeouts
     probeTimeouts:
       liveness:
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 5
-        successThreshold: 1
-      readiness:
-        initialDelaySeconds: 10
-        periodSeconds: 10
+        initialDelaySeconds: 20
+        periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 5
         successThreshold: 2
+      readiness:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
       startup:
         initialDelaySeconds: 10
         periodSeconds: 5
-        timeoutSeconds: 2
+        timeoutSeconds: 3
         failureThreshold: 60
         successThreshold: 1
     # -- Define a postgresql version for CNPG
@@ -200,7 +200,7 @@ workload:
               port: "{{ $.Values.service.main.ports.main.targetPort | default .Values.service.main.ports.main.port }}"
             startup:
               enabled: true
-              type: "tcp"
+              type: "{{ .Values.service.main.ports.main.protocol }}"
               port: "{{ $.Values.service.main.ports.main.targetPort | default .Values.service.main.ports.main.port }}"
 
 # -- Timezone used everywhere applicable

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -38,7 +38,7 @@ global:
         periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 5
-        successThreshold: 2
+        successThreshold: 1
       readiness:
         initialDelaySeconds: 20
         periodSeconds: 10


### PR DESCRIPTION
**Description**
There is a design mistake in the probe setup:

Liveness probe:
Stops the container on failure, this should happen AFTER readiness probe detects failure.

Readiness Probe:
Stops the service forwarding traffic. This should happen BEFORE the liveness probe detects failure

Startup Probe:
By having a tcp startup-probe, charts might pass CI when not fully working. or, worse, get passed-over to the readiness/liveness probes when the container is still doing maintenance work (such as plex database updates). Leading to it right-away being thrown-out by liveness/readyness

I also attempted to offset start of liveness and readyness, this ensures they don't send probes at the same time, while making it most-likely that liveness clears before readiness on startup.

While also offsetting the intervals, to prevent the same while running

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
