### PR TITLE
fix(traefik): remove enableFixedMiddlewares key from global

### DIFF
--- a/library/common-test/tests/ingress/traefik_test.yaml
+++ b/library/common-test/tests/ingress/traefik_test.yaml
@@ -237,37 +237,9 @@ tests:
             traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
             traefik.ingress.kubernetes.io/router.middlewares: test-release-namespace-chain-basic@kubernetescrd
 
-  - it: should not contain fixed middlewares when global is disabled
+  - it: should not contain fixed middlewares when are disabled
     set:
       service: *service
-      global:
-        traefik:
-          enableFixedMiddlewares: false
-      ingress:
-        my-ingress:
-          enabled: true
-          primary: true
-          integrations:
-            traefik:
-              enabled: true
-          hosts: *hosts
-    asserts:
-      - documentIndex: *ingressDoc
-        isKind:
-          of: Ingress
-      - documentIndex: *ingressDoc
-        isSubset:
-          path: metadata.annotations
-          content:
-            traefik.ingress.kubernetes.io/router.tls: "true"
-            traefik.ingress.kubernetes.io/router.entrypoints: websecure
-
-  - it: should not contain fixed middlewares when local is disabled
-    set:
-      service: *service
-      global:
-        traefik:
-          enableFixedMiddlewares: true
       ingress:
         my-ingress:
           enabled: true

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 24.0.0
+version: 24.0.1
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/lib/ingress/integrations/_traefik.tpl
+++ b/library/common/templates/lib/ingress/integrations/_traefik.tpl
@@ -14,10 +14,9 @@
 
     {{- $fixedMiddlewares := list -}}
     {{- $allowCorsMiddlewares := list -}}
-    {{- $enableFixed := false -}}
+    {{- $enableFixed := true -}}
     {{- if (hasKey $rootCtx.Values.global "traefik") -}}
       {{- $fixedMiddlewares = $rootCtx.Values.global.traefik.fixedMiddlewares -}}
-      {{- $enableFixed = $rootCtx.Values.global.traefik.enableFixedMiddlewares -}}
       {{- $allowCorsMiddlewares = $rootCtx.Values.global.traefik.allowCorsMiddlewares -}}
     {{- end -}}
 
@@ -26,7 +25,6 @@
       {{- $fixedMiddlewares = $traefik.fixedMiddlewares -}}
     {{- end -}}
 
-    {{/* Replace global fixed with local fixed */}}
     {{- if and (hasKey $traefik "enableFixedMiddlewares") (kindIs "bool" $traefik.enableFixedMiddlewares) -}}
       {{- $enableFixed = $traefik.enableFixedMiddlewares -}}
     {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -628,7 +628,6 @@ ingress:
         # Default to websecure
         entrypoints:
           - websecure
-        enableFixedMiddlewares: true
         # Ensures tls annotation is set
         forceTLS: true
         # Drops both global and local fixedMiddlewares when enabled


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  https://github.com/truecharts/library-charts/issues/825

Having the `enableFixedMiddlewares` defined by **default** in `main` ingress, will cause the fixed middlewares to always be enabled, even if global is disabled.

Code is structured in a way that will ignore ingress level toggle if the key is missing completely. So the global will take effect.

Note:
It might be breaking for existing users that explicitly disabled fixed middlewares from global, but left the "default" on main.


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
