### PR TITLE
fix(pdb): Pod Disruption Budgets have spec not data

### DIFF
--- a/library/common-test/tests/podDisruptionBudget/spec_test.yaml
+++ b/library/common-test/tests/podDisruptionBudget/spec_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: PodDisruptionBudget
       - documentIndex: *pdbDoc
         isSubset:
-          path: data
+          path: spec
           content:
             minAvailable: 0
             maxUnavailable: 0
@@ -41,7 +41,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         isSubset:
-          path: data
+          path: spec
           content:
             minAvailable: 0
             maxUnavailable: 0
@@ -60,7 +60,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         isSubset:
-          path: data
+          path: spec
           content:
             minAvailable: 50%
             maxUnavailable: 50%
@@ -76,7 +76,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         equal:
-          path: data.minAvailable
+          path: spec.minAvailable
           value: 1
 
   - it: should pass with maxUnavailable defined
@@ -90,7 +90,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         equal:
-          path: data.maxUnavailable
+          path: spec.maxUnavailable
           value: 2
 
   - it: should pass with unhealthyPodEvictionPolicy defined
@@ -105,7 +105,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         equal:
-          path: data.unhealthyPodEvictionPolicy
+          path: spec.unhealthyPodEvictionPolicy
           value: IfHealthyBudget
 
   - it: should create custom labels for selector
@@ -120,7 +120,7 @@ tests:
     asserts:
       - documentIndex: *pdbDoc
         equal:
-          path: data.selector.matchLabels
+          path: spec.selector.matchLabels
           value:
             label1: value1
             label2: value2
@@ -143,7 +143,7 @@ tests:
           of: PodDisruptionBudget
       - documentIndex: *pdbDoc
         equal:
-          path: data.selector.matchLabels
+          path: spec.selector.matchLabels
           value:
             pod.name: my-pod
             app.kubernetes.io/name: common-test

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 24.0.5
+version: 24.0.6
 annotations:
   artifacthub.io/category: "integration-delivery"
   artifacthub.io/license: "BUSL-1.1"

--- a/library/common/templates/class/_podDisruptionBudget.tpl
+++ b/library/common/templates/class/_podDisruptionBudget.tpl
@@ -31,7 +31,7 @@ metadata:
   annotations:
     {{- . | nindent 4 }}
   {{- end }}
-data:
+spec:
   selector:
     matchLabels:
     {{- if $objectData.customLabels -}}


### PR DESCRIPTION
**Description**
Pod Disruption Budgets don't contain a data field but a spec one.

This doesn't cause an error immediately since k8s ignores unknown fields, but renders all existing PDBs useless
as they are not properly configured. 

⚒️ Fixes  # <!--(issue)-->

Didn't managed to make an issue but went straight to fixing it :)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
The existing test suite is good enough I simply modified it to expect a `spec` field rather than a `data` one.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
