### PR TITLE
fix(pdb): remove default maxUnavailable/minAvailable values

### DIFF
--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -728,9 +728,9 @@ podDisruptionBudget:
     # -- Custom Selector Labels
     # customLabels:
     #   customKey: customValue
+    # maxUnavailable: 1
+    # minAvailable: 1
     targetSelector: main
-    minAvailable: 1
-    maxUnavailable: 1
 
 webhook:
   validating:


### PR DESCRIPTION
**Description**
Currently, both `maxUnavailable` and `minAvailable` are set to `1` in common.yaml. This results in bolt values being set if `PodDisruptionBudget` is enabled in any Helm charts. Having both fields set results in Argo failing to sync, because they are mutually-exclusive. 

The docs already note that one of these fields must be set: https://truecharts.org/common/poddisruptionbudget/#name, so I do not think they should both be set by default, since it is more prone to error.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
